### PR TITLE
Reduce number of database queries

### DIFF
--- a/pdc/apps/common/renderers.py
+++ b/pdc/apps/common/renderers.py
@@ -263,7 +263,7 @@ def _get_details_for_slug(serializer, field_name, field):
     displayed.
     """
     model = ''
-    if hasattr(field, 'queryset') and field.queryset:
+    if hasattr(field, 'queryset') and hasattr(field.queryset, 'model'):
         model = field.queryset.model.__name__ + '.'
     return '%s%s' % (model, field.slug_field)
 

--- a/pdc/apps/common/viewsets.py
+++ b/pdc/apps/common/viewsets.py
@@ -146,6 +146,8 @@ class StrictQueryParamMixin(object):
     `query_params` class attribute on the serializer. Note that this should
     only include the parameters that are passed via URL query string, not
     request body fields.
+
+    It also provides some helper functions for examining request.
     """
     def initial(self, request, *args, **kwargs):
         super(StrictQueryParamMixin, self).initial(request, *args, **kwargs)
@@ -161,6 +163,14 @@ class StrictQueryParamMixin(object):
         extra_keys = set(request.query_params.keys()) - allowed_keys
         if extra_keys:
             raise FieldError('Unknown query params: %s.' % ', '.join(sorted(extra_keys)))
+
+    def is_filtered_list(self):
+        """Return True if the current action is list and pagination is enabled.
+
+        This may be handy for adding prefetching of related models from
+        database.
+        """
+        return self.action == 'list' and self.paginator.get_page_size(self.request)
 
 
 class PDCModelViewSet(StrictQueryParamMixin,

--- a/pdc/apps/partners/views.py
+++ b/pdc/apps/partners/views.py
@@ -37,7 +37,7 @@ class PartnerTypeViewSet(StrictQueryParamMixin,
 
 
 class PartnerViewSet(PDCModelViewSet):
-    queryset = models.Partner.objects.all().order_by('id')
+    queryset = models.Partner.objects.select_related('type').order_by('id')
     lookup_field = 'short'
     serializer_class = serializers.PartnerSerializer
     filter_class = filters.PartnerFilterSet

--- a/pdc/apps/release/views.py
+++ b/pdc/apps/release/views.py
@@ -758,7 +758,7 @@ class ReleaseVariantViewSet(ChangeSetModelMixin,
         # Preloading with a separate request could be actually be slow if there
         # is no filter, so it's done only on list request with paging enabled.
         queryset = self.queryset.select_related('variant_type', 'release')
-        if self.action == 'list' and self.paginator.get_page_size(self.request):
+        if self.is_filtered_list():
             queryset = queryset.prefetch_related('variantarch_set__arch')
         return queryset
 


### PR DESCRIPTION
These are minor improvements that improved performance while working on the partners ui. I'm not completely sure the approach from the first commit is the best option. Adding `prefetch_related` unconditionally broke the tests.