### PR TITLE
Specify Accept instead of Content-Type in curl examples.

### DIFF
--- a/pdc/apps/auth/__init__.py
+++ b/pdc/apps/auth/__init__.py
@@ -128,7 +128,7 @@ Using Token
 -----------
 
     # obtain token
-    curl --negotiate -u : -H "Content-Type: application/json"  https://pdc.example.com/rest_api/v1/auth/token/obtain
+    curl --negotiate -u : -H "Accept: application/json"  https://pdc.example.com/rest_api/v1/auth/token/obtain
     # you will get a `Response` like:
     {"token": "00bf04e8187f6e6d54f510515e8bde88e5bb7904"}
 

--- a/pdc/apps/auth/views.py
+++ b/pdc/apps/auth/views.py
@@ -116,7 +116,7 @@ class TokenViewSet(StrictQueryParamMixin, viewsets.ViewSet):
 
     * obtain token
 
-            curl --negotiate -u : -H "Content-Type: application/json"  $URL:token-obtain$
+            curl --negotiate -u : -H "Accept: application/json"  $URL:token-obtain$
 
         you will get a `Response` like:
 
@@ -132,7 +132,7 @@ class TokenViewSet(StrictQueryParamMixin, viewsets.ViewSet):
 
     * in case you want refresh your token, you can do it with:
 
-            curl --negotiate -u : -H "Content-Type: application/json"  $URL:token-refresh$
+            curl --negotiate -u : -H "Accept: application/json"  $URL:token-refresh$
 
         you will get a `Response` with refreshed token:
 
@@ -157,7 +157,7 @@ class TokenViewSet(StrictQueryParamMixin, viewsets.ViewSet):
 
         Run:
 
-            curl --negotiate -u : -H "Content-Type: application/json"  $URL:token-obtain$
+            curl --negotiate -u : -H "Accept: application/json"  $URL:token-obtain$
 
         you will get a `Response` like:
 
@@ -186,9 +186,9 @@ class TokenViewSet(StrictQueryParamMixin, viewsets.ViewSet):
 
         Run:
 
-            curl --negotiate -u : -H "Content-Type: application/json"  $URL:token-refresh$
+            curl --negotiate -u : -H "Accept: application/json"  $URL:token-refresh$
             # or
-            curl --negotiate -u : -X PUT -H "Content-Type: application/json"  $URL:token-refresh$
+            curl --negotiate -u : -X PUT -H "Accept: application/json"  $URL:token-refresh$
 
         you will get a `Response` with refreshed token:
 
@@ -242,7 +242,7 @@ class PermissionViewSet(StrictQueryParamMixin,
 
         __Example__:
 
-            curl -H "Content-Type: application/json"  -X GET $URL:permission-list$
+            curl -H "Accept: application/json"  -X GET $URL:permission-list$
             # output
             {
                 "count": 150,
@@ -260,7 +260,7 @@ class PermissionViewSet(StrictQueryParamMixin,
 
         With query params:
 
-            curl -H "Content-Type: application/json"  -G $URL:permission-list$ --data-urlencode "codename=add_logentry"
+            curl -H "Accept: application/json"  -G $URL:permission-list$ --data-urlencode "codename=add_logentry"
             # output
             {
                 "count": 1,


### PR DESCRIPTION
I'm pretty sure this is what we want here.

Content-Type specifies what kind of data we're sending.. but we're not sending json here.

Accept specifies what kind of data you want back.. and we want JSON (not the html docs served at the same endpoint).