### PR TITLE
A slightly more friendly default 404 response.

### DIFF
--- a/pdc/apps/common/handlers.py
+++ b/pdc/apps/common/handlers.py
@@ -41,7 +41,7 @@ def exception_handler(exc, context):
             return Response({'detail': msg},
                             status=status.HTTP_400_BAD_REQUEST)
         elif isinstance(exc, exceptions.ObjectDoesNotExist):
-            return Response(NOT_FOUND_JSON_RESPONSE,
+            return Response({'detail': 'Not found:  %s' % str(exc)},
                             status=status.HTTP_404_NOT_FOUND)
         elif isinstance(exc, ProtectedError):
             return Response({"detail": "%s %s" % exc.args},


### PR DESCRIPTION
When trying to import a compose, I kept getting a 404.

- It was hard to uncover the json error response from pdc-client,
- but once I got it, it was vague.  Just ``{'detail': 'Not found'}``.

It was only after I modified the pdc server code to include more
information, did I find it was because I needed to specify a missing
Arch entry.  Including the exception representation like this should
make it easier to solve problems like this in the future.