### PR TITLE
Add format filter for build-image-rtt-tests and fix a bug.

### DIFF
--- a/pdc/apps/package/filters.py
+++ b/pdc/apps/package/filters.py
@@ -155,7 +155,8 @@ class BuildImageFilter(django_filters.FilterSet):
 class BuildImageRTTTestsFilter(django_filters.FilterSet):
     build_nvr = MultiValueFilter(name='image_id')
     test_result = MultiValueFilter(name='test_result__name')
+    image_format = MultiValueFilter(name='image_format__name')
 
     class Meta:
         model = models.BuildImage
-        fields = ('build_nvr', 'test_result')
+        fields = ('build_nvr', 'test_result', 'image_format')

--- a/pdc/apps/package/serializers.py
+++ b/pdc/apps/package/serializers.py
@@ -211,7 +211,7 @@ class BuildImageSerializer(StrictSerializerMixin, serializers.HyperlinkedModelSe
 
 
 class BuildImageRTTTestsSerializer(StrictSerializerMixin, serializers.ModelSerializer):
-    format = serializers.CharField(source='image_format__name', read_only=True)
+    format = serializers.CharField(source='image_format.name', read_only=True)
     test_result = ChoiceSlugField(slug_field='name', queryset=ComposeAcceptanceTestingState.objects.all())
     build_nvr = serializers.CharField(source='image_id', read_only=True)
 

--- a/pdc/apps/package/tests.py
+++ b/pdc/apps/package/tests.py
@@ -1630,13 +1630,22 @@ class BuildImageRTTTestsRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         untested_count = response.data['count']
         self.assertEqual(0, untested_count)
 
-    def test_filter_build_image_test_results_with_test_nvr_and_test_result(self):
+    def test_filter_build_image_test_results_with_format(self):
+        url = reverse('buildimagertttests-list')
+        response = self.client.get(url + '?image_format=docker', format='json')
+        untested_count = response.data['count']
+        self.assertEqual(untested_count, 2)
+
+        response = self.client.get(url + '?image_format=iso', format='json')
+        untested_count = response.data['count']
+        self.assertEqual(0, untested_count)
+
+    def test_filter_build_image_test_results_with_combinations(self):
         url = reverse('buildimagertttests-list')
         response = self.client.get(url + '?build_nvr=my-server-docker-1.0-27', format='json')
         count = response.data['count']
         self.assertEqual(count, 1)
 
-        url = reverse('buildimagertttests-list')
         response = self.client.get(url + '?build_nvr=fake_nvr', format='json')
         count = response.data['count']
         self.assertEqual(count, 0)
@@ -1656,12 +1665,19 @@ class BuildImageRTTTestsRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         count = response.data['count']
         self.assertEqual(count, 2)
 
-        url = reverse('buildimagertttests-list')
         response = self.client.get(url + '?build_nvr=my-server-docker-1.0-27&test_result=untested', format='json')
         count = response.data['count']
         self.assertEqual(count, 2)
 
-        url = reverse('buildimagertttests-list')
+        response = self.client.get(url + '?image_format=docker&build_nvr=my-client-docker', format='json')
+        untested_count = response.data['count']
+        self.assertEqual(1, untested_count)
+
+        response = self.client.get(url + '?build_nvr=my-server-docker-1.0-27&test_result=untested&image_format=iso',
+                                   format='json')
+        count = response.data['count']
+        self.assertEqual(count, 1)
+
         response = self.client.get(url + '?build_nvr=my-server-docker-1.0-27&test_result=passed', format='json')
         count = response.data['count']
         self.assertEqual(count, 0)

--- a/pdc/apps/package/views.py
+++ b/pdc/apps/package/views.py
@@ -447,6 +447,7 @@ class BuildImageRTTTestsViewSet(pdc_viewsets.StrictQueryParamMixin,
               "results": [
                 {
                     "build_nvr":    string,
+                    "format":       string,
                     "id":           int,
                     "test_result":  string
                 },
@@ -467,6 +468,7 @@ class BuildImageRTTTestsViewSet(pdc_viewsets.StrictQueryParamMixin,
 
             {
                 "build_nvr":    string,
+                "format":       string,
                 "id":           int,
                 "test_result":  string
             }
@@ -483,6 +485,7 @@ class BuildImageRTTTestsViewSet(pdc_viewsets.StrictQueryParamMixin,
 
             {
                 "build_nvr":    string,
+                "format":       string,
                 "id":           int,
                 "test_result":  string
             }


### PR DESCRIPTION
1. Add format filter for resource build-image-rtt-tests
2. Fix a output bug.

JIRA: PDC-1205