### PR TITLE
Add compose image RTT tests APIs.

### DIFF
--- a/pdc/apps/compose/filters.py
+++ b/pdc/apps/compose/filters.py
@@ -9,8 +9,8 @@ import django_filters
 from django.db.models import Q
 from django.core.exceptions import ValidationError
 
-from pdc.apps.common.filters import value_is_not_empty
-from .models import Compose, OverrideRPM, ComposeTree
+from pdc.apps.common.filters import value_is_not_empty, MultiValueFilter
+from .models import Compose, OverrideRPM, ComposeTree, ComposeImage
 
 
 class ComposeFilter(django_filters.FilterSet):
@@ -89,3 +89,15 @@ class ComposeTreeFilter(django_filters.FilterSet):
     class Meta:
         model = ComposeTree
         fields = ('compose', 'variant', 'arch', 'location', 'scheme')
+
+
+class ComposeImageRTTTestFilter(django_filters.FilterSet):
+    compose         = MultiValueFilter(name='variant_arch__variant__compose__compose_id')
+    variant         = MultiValueFilter(name='variant_arch__variant__variant_uid')
+    arch            = MultiValueFilter(name='variant_arch__arch__name')
+    file_name       = MultiValueFilter(name='image__file_name')
+    test_result     = MultiValueFilter(name='rtt_test_result__name')
+
+    class Meta:
+        model = ComposeImage
+        fields = ('compose', 'variant', 'arch', 'file_name', 'test_result')

--- a/pdc/apps/compose/fixtures/tests/compose_composeimage.json
+++ b/pdc/apps/compose/fixtures/tests/compose_composeimage.json
@@ -12,6 +12,7 @@
     "fields": {
         "variant_arch": 1,
         "image": 1,
+        "rtt_test_result": 1,
         "path": 1
     }
   },
@@ -21,6 +22,7 @@
     "fields": {
         "variant_arch": 1,
         "image": 2,
+        "rtt_test_result": 1,
         "path": 1
     }
   },
@@ -30,6 +32,7 @@
     "fields": {
         "variant_arch": 1,
         "image": 3,
+        "rtt_test_result": 1,
         "path": 1
     }
   }

--- a/pdc/apps/compose/migrations/0008_composeimage_rtt_test_result.py
+++ b/pdc/apps/compose/migrations/0008_composeimage_rtt_test_result.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import pdc.apps.compose.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('compose', '0007_auto_20151120_0336'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='composeimage',
+            name='rtt_test_result',
+            field=models.ForeignKey(default=pdc.apps.compose.models.ComposeAcceptanceTestingState.get_untested, to='compose.ComposeAcceptanceTestingState'),
+        ),
+    ]

--- a/pdc/apps/compose/models.py
+++ b/pdc/apps/compose/models.py
@@ -3,6 +3,7 @@
 # Licensed under The MIT License (MIT)
 # http://opensource.org/licenses/MIT
 #
+from django.core.exceptions import ValidationError
 from django.db import models, connection, transaction
 from django.db.utils import IntegrityError
 
@@ -223,6 +224,11 @@ class Path(models.Model):
 
     def __unicode__(self):
         return unicode(self.path)
+
+    def export(self):
+        return {
+            "path": self.path
+        }
 
     CACHE = {}
 
@@ -501,11 +507,40 @@ class ComposeImage(models.Model):
     variant_arch        = models.ForeignKey(VariantArch, db_index=True)
     image               = models.ForeignKey("package.Image", db_index=True)
     path                = models.ForeignKey(Path)
+    rtt_test_result     = models.ForeignKey(ComposeAcceptanceTestingState,
+                                            default=ComposeAcceptanceTestingState.get_untested)
 
     class Meta:
         unique_together = (
             ("variant_arch", "image"),
         )
+
+    def __unicode__(self):
+        return u"%s/%s" % (self.variant_arch.variant.compose, self.image)
+
+    def export(self):
+        return {
+            "compose": self.variant_arch.variant.compose.compose_id,
+            "variant": self.variant_arch.variant.variant_uid,
+            "arch": self.variant_arch.arch.name,
+            "file_name": self.image.file_name,
+            "path": self.path.path,
+            "test_result": self.rtt_test_result.name
+        }
+
+    def validate_unique(self, exclude=None):
+        super(ComposeImage, self).validate_unique(exclude=exclude)
+        # NOTE(xchu): we assume that for each compose in specific variant_arch,
+        #             the image `file_name` should be unique.
+        if not self.id:
+            qs = self.__class__.objects.filter(variant_arch=self.variant_arch,
+                                               image__file_name=self.image.file_name)
+            if qs.exists():
+                raise ValidationError(
+                    "Unique validation Error in ComposeImage. "
+                    "Compose(%s) with same Image file name(%s) already exists." % (
+                        self.variant_arch.variant.compose, self.image.file_name)
+                )
 
 
 class Location(models.Model):

--- a/pdc/apps/compose/routers.py
+++ b/pdc/apps/compose/routers.py
@@ -35,3 +35,5 @@ router.register('rpc/find-composes-by-product-version-rpm/(?P<product_version>[^
                 base_name='findcomposesbypvr')
 router.register(r'compose-tree-locations', views.ComposeTreeViewSet,
                 base_name='composetreelocations')
+router.register(r'compose-image-rtt-tests', views.ComposeImageRTTTestViewSet,
+                base_name='composeimagertttests')


### PR DESCRIPTION
JIRA: PDC-1191

With the constraint that each compose in specific variant arch the image `file_name` instead of (`file_name`, `sha256`) is unique, we could use `compose/variant/arch/file_name` as lookup key.