### PR TITLE
Rpc/release/clone-components

### DIFF
--- a/pdc/apps/component/models.py
+++ b/pdc/apps/component/models.py
@@ -289,6 +289,7 @@ class ReleaseComponentRelationship(models.Model):
         return result
 
 
+@receiver(signals.rpc_release_clone_component)
 @receiver(signals.release_clone)
 def clone_release_components_and_groups(sender, request, original_release, release, **kwargs):
     data = request.data

--- a/pdc/apps/component/tests.py
+++ b/pdc/apps/component/tests.py
@@ -1175,6 +1175,31 @@ class ReleaseCloneWithComponentsTestCase(TestCaseWithChangeSetMixin, APITestCase
         self.assertIn('Value [foobar] of include_inactive is not a boolean',
                       response.content)
 
+    def test_release_components_clone(self):
+        args = {"name": "Supplementary", "short": "supp", "version": "1.1",
+                "release_type": "ga"}
+        target_response = self.client.post(reverse('release-list'), args)
+        self.assertEqual(target_response.status_code, status.HTTP_201_CREATED)
+        target_release_id = target_response.data['release_id']
+        response = self.client.post(reverse('releasecomponentclone-list'),
+                                    {'source_release_id': 'release-1.0',
+                                     'target_release_id': target_release_id,
+                                     'component_dist_git_branch': 'new_branch'},
+                                    format='json')
+        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+
+    def test_release_component_clone_whithout_component(self):
+        args = {"name": "Supplementary", "short": "supp", "version": "1.1",
+                "release_type": "ga"}
+        source_response = self.client.post(reverse('release-list'), args)
+        self.assertEqual(source_response.status_code, status.HTTP_201_CREATED)
+        resource_release_id = source_response.data['release_id']
+        response = self.client.post(reverse('releasecomponentclone-list'),
+                                    {'source_release_id': resource_release_id,
+                                     'target_release_id': 'release-1.0'},
+                                    format='json')
+        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
+
 
 class BugzillaComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
     fixtures = [

--- a/pdc/apps/release/models.py
+++ b/pdc/apps/release/models.py
@@ -308,6 +308,7 @@ class Variant(models.Model):
         }
 
 
+@receiver(signals.rpc_release_clone_component)
 @receiver(signals.release_clone)
 def clone_variants(sender, request, original_release, release, **kwargs):
     """

--- a/pdc/apps/release/routers.py
+++ b/pdc/apps/release/routers.py
@@ -23,6 +23,10 @@ router.register(r'rpc/release/import-from-composeinfo',
 router.register(r'rpc/release/clone',
                 views.ReleaseCloneViewSet,
                 base_name='releaseclone')
+router.register(r'rpc/release/clone-components',
+                views.ReleaseComponentCloneViewSet,
+                base_name='releasecomponentclone'
+                )
 router.register(r'release-variants',
                 views.ReleaseVariantViewSet)
 router.register(r'variant-types', views.VariantTypeViewSet,

--- a/pdc/apps/release/signals.py
+++ b/pdc/apps/release/signals.py
@@ -24,6 +24,12 @@ release_clone = dispatch.Signal(providing_args=['request',
                                                 'original_release',
                                                 'release'])
 
+# This signal is sent when want to clone components from one release to another.
+# The way is to copy all release components, component groups and relationships.
+rpc_release_clone_component = dispatch.Signal(providing_args=['request',
+                                                              'original_release',
+                                                              'release'])
+
 # This signal is sent before validated data is converted into a Release
 # instance. Any module that has additional fields in the dict should remove it
 # and store it for further processing.


### PR DESCRIPTION
This patch is used to clone release components from one  release to another release.
 The result will return target release.

JIRA: PDC-1204
sub JIRA: PDC-1252