### PR TITLE
Handle ValueError in exception_handler

### DIFF
--- a/pdc/apps/common/handlers.py
+++ b/pdc/apps/common/handlers.py
@@ -46,6 +46,9 @@ def exception_handler(exc, context):
         elif isinstance(exc, ProtectedError):
             return Response({"detail": "%s %s" % exc.args},
                             status=status.HTTP_400_BAD_REQUEST)
+        elif isinstance(exc, ValueError):
+            return Response({'detail': str(exc)},
+                            status=status.HTTP_400_BAD_REQUEST)
         elif isinstance(exc, db.IntegrityError):
             # Refs PEP249
             # Maybe a duplicate PK, FK check fails, index conflict.


### PR DESCRIPTION
When called compose-rpms api and rpm date info was
not correct, productmd would throw ValueError exception and
cause server internal error (500 error).
Now let exception_handler handle ValueError exception then server
will response http code 400 and meaningful message.