### PR TITLE
Some improvements for stare image test results.

### DIFF
--- a/pdc/apps/compose/serializers.py
+++ b/pdc/apps/compose/serializers.py
@@ -148,7 +148,7 @@ class ComposeTreeSerializer(StrictSerializerMixin,
 class ComposeImageRTTTestSerializer(StrictSerializerMixin,
                                     DynamicFieldsSerializerMixin,
                                     serializers.ModelSerializer):
-    compose                 = serializers.CharField(source='variant_arch.variant.compose', read_only=True)
+    compose                 = serializers.CharField(source='variant_arch.variant.compose.compose_id', read_only=True)
     variant                 = serializers.CharField(source='variant_arch.variant', read_only=True)
     arch                    = serializers.CharField(source='variant_arch.arch', read_only=True)
     file_name               = serializers.CharField(source='image.file_name', read_only=True)
@@ -158,13 +158,3 @@ class ComposeImageRTTTestSerializer(StrictSerializerMixin,
     class Meta:
         model = ComposeImage
         fields = ('compose', 'variant', 'arch', 'file_name', 'test_result')
-
-    def to_internal_value(self, data):
-        ret = {}
-        if 'test_result' in data:
-            try:
-                ret['rtt_test_result'] = ComposeAcceptanceTestingState.objects.get(
-                    name=data.get('test_result'))
-            except Exception as e:
-                raise serializers.ValidationError({"test_result": e})
-        return ret

--- a/pdc/apps/compose/tests.py
+++ b/pdc/apps/compose/tests.py
@@ -2110,7 +2110,7 @@ class ComposeImageRTTTestAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
                                      {'test_result': 'unknown'})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data.get('test_result'),
-                         'ComposeAcceptanceTestingState matching query does not exist.')
+                         ["'unknown' is not allowed value. Use one of 'untested', 'passed', 'failed'."])
         self.assertNumChanges([])
 
     def test_can_bulk_update_test_result(self):


### PR DESCRIPTION
1. Use compose id as compose out put, not compose model unicode.
   So the filter and output is consistent.
2. Response test_result illegal with default ChoiceSlugField behavior.
   It is more clear.

JIRA: PDC-1191