### PR TITLE
Rpc/release/clone-components

### DIFF
--- a/pdc/apps/release/models.py
+++ b/pdc/apps/release/models.py
@@ -308,7 +308,6 @@ class Variant(models.Model):
         }
 
 
-@receiver(signals.rpc_release_clone_component)
 @receiver(signals.release_clone)
 def clone_variants(sender, request, original_release, release, **kwargs):
     """

--- a/pdc/apps/release/views.py
+++ b/pdc/apps/release/views.py
@@ -652,7 +652,6 @@ class ReleaseComponentCloneViewSet(StrictQueryParamMixin, viewsets.GenericViewSe
                 "target_release_id":            string
                 "component_dist_git_branch":    string,     # optional
                 "include_inactive":             bool,       # optional
-                "include_trees":                [string],   # optional
             }
         __Response__:
             {
@@ -666,10 +665,6 @@ class ReleaseComponentCloneViewSet(StrictQueryParamMixin, viewsets.GenericViewSe
         If `include_inactive` is False, the inactive release_components belong to
         the old release won't be cloned to target release.
         Default it will clone all release_components to target release.
-
-        If `include_tree` is specified, it should contain a list of
-        Variant.Arch pairs that should be cloned. If not given, all trees will
-        be cloned. If the list is empty, no trees will be cloned.
         """
         data = request.data
         if 'source_release_id' not in data:


### PR DESCRIPTION
Remove the 'include_trees' para in component clone. This ideal
get from lubomir; means that don't need to clone variant.

By the way, we don't need to create release-repo clone
in this task.

JIRA: PDC-1204
subTask: PDC-1052