### PR TITLE
Add error info when input error para

### DIFF
--- a/pdc/apps/component/tests.py
+++ b/pdc/apps/component/tests.py
@@ -1200,6 +1200,20 @@ class ReleaseCloneWithComponentsTestCase(TestCaseWithChangeSetMixin, APITestCase
                                     format='json')
         self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
 
+    def test_release_component_clone_with_error_target_release(self):
+        response = self.client.post(reverse('releasecomponentclone-list'),
+                                    {'source_release_id': 'release-1.0',
+                                     'target_release_id': 'xxxx-1.0'},
+                                    format='json')
+        self.assertEquals(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_release_component_clone_with_error_source_release(self):
+        response = self.client.post(reverse('releasecomponentclone-list'),
+                                    {'source_release_id': 'xxxx-1.0',
+                                     'target_release_id': 'release-1.0'},
+                                    format='json')
+        self.assertEquals(response.status_code, status.HTTP_404_NOT_FOUND)
+
 
 class BugzillaComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
     fixtures = [

--- a/pdc/apps/release/views.py
+++ b/pdc/apps/release/views.py
@@ -678,12 +678,12 @@ class ReleaseComponentCloneViewSet(StrictQueryParamMixin, viewsets.GenericViewSe
         try:
             source_release = get_object_or_404(models.Release, release_id=source_release_id)
         except Http404:
-            return Response({'detail': 'Source_release_id is not existed'},
+            return Response({'detail': 'Source_release %s is not existed' % source_release_id},
                             status=status.HTTP_404_NOT_FOUND)
         try:
             target_release = get_object_or_404(models.Release, release_id=target_release_id)
         except Http404:
-            return Response({'detail': 'Target_release_id is not existed'},
+            return Response({'detail': 'Target_release %s is not existed' % target_release_id},
                             status=status.HTTP_404_NOT_FOUND)
         if source_release.releasecomponent_set.count() == 0:
             return Response({'detail': 'there is no component in source release'},


### PR DESCRIPTION
This patch will add error info when Source_release or Target_release
is not existed. And then, update the decription in webUI.

JIRA:PDC-1204