### PR TITLE
Allow PATCH on build-image-rtt-tests with build_nvr/format

### DIFF
--- a/pdc/apps/package/tests.py
+++ b/pdc/apps/package/tests.py
@@ -1610,7 +1610,7 @@ class BuildImageRTTTestsRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def test_build_image_test_result_should_not_be_deleted(self):
-        url = reverse('buildimagertttests-detail', args=[1])
+        url = reverse('buildimagertttests-detail', args=['my-server-docker-1.0-27/docker'])
         response = self.client.delete(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
@@ -1686,8 +1686,7 @@ class BuildImageRTTTestsRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         url = reverse('buildimagertttests-list')
         response = self.client.get(url + '?test_result=untested', format='json')
         ori_untested_count = response.data['count']
-
-        url = reverse('buildimagertttests-detail', args=[1])
+        url = reverse('buildimagertttests-detail', args=['my-server-docker-1.0-27/docker'])
         data = {'test_result': 'passed'}
         response = self.client.patch(url, data, format='json')
 
@@ -1703,37 +1702,37 @@ class BuildImageRTTTestsRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
 
     def test_patch_build_image_test_results_not_allowed_fields(self):
         data = {'build_nvr': 'fake_nvr', 'format': 'iso', 'test_result': 'untested'}
-        url = reverse('buildimagertttests-detail', args=[1])
+        url = reverse('buildimagertttests-detail', args=['my-server-docker-1.0-27/docker'])
         response = self.client.patch(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         data = {'format': 'iso', 'test_result': 'untested'}
-        url = reverse('buildimagertttests-detail', args=[1])
+        url = reverse('buildimagertttests-detail', args=['my-server-docker-1.0-27/docker'])
         response = self.client.patch(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         data = {'build_nvr': 'fake_nvr', 'test_result': 'untested'}
-        url = reverse('buildimagertttests-detail', args=[1])
+        url = reverse('buildimagertttests-detail', args=['my-server-docker-1.0-27/docker'])
         response = self.client.patch(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         data = {'format': 'iso'}
-        url = reverse('buildimagertttests-detail', args=[1])
+        url = reverse('buildimagertttests-detail', args=['my-server-docker-1.0-27/docker'])
         response = self.client.patch(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         data = {'build_nvr': 'fake_nvr'}
-        url = reverse('buildimagertttests-detail', args=[1])
+        url = reverse('buildimagertttests-detail', args=['my-server-docker-1.0-27/docker'])
         response = self.client.patch(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_patch_empty_content_should_not_allowed(self):
-        url = reverse('buildimagertttests-detail', args=[1])
+        url = reverse('buildimagertttests-detail', args=['my-server-docker-1.0-27/docker'])
         response = self.client.patch(url, {}, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_put_method_should_not_allowed(self):
         data = {'build_nvr': 'my-server-docker-1.0-27', 'format': 'docker', 'test_result': 'untested'}
-        url = reverse('buildimagertttests-detail', args=[1])
+        url = reverse('buildimagertttests-detail', args=['my-server-docker-1.0-27/docker'])
         response = self.client.put(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/pdc/apps/package/views.py
+++ b/pdc/apps/package/views.py
@@ -417,6 +417,7 @@ class BuildImageViewSet(pdc_viewsets.PDCModelViewSet):
 
 class BuildImageRTTTestsViewSet(pdc_viewsets.StrictQueryParamMixin,
                                 pdc_viewsets.ChangeSetUpdateModelMixin,
+                                pdc_viewsets.MultiLookupFieldMixin,
                                 mixins.RetrieveModelMixin,
                                 mixins.ListModelMixin,
                                 viewsets.GenericViewSet):
@@ -426,6 +427,8 @@ class BuildImageRTTTestsViewSet(pdc_viewsets.StrictQueryParamMixin,
     queryset = models.BuildImage.objects.all().order_by('id')
     serializer_class = serializers.BuildImageRTTTestsSerializer
     filter_class = filters.BuildImageRTTTestsFilter
+    lookup_fields = (('image_id', r'[^/]+'),
+                     ('image_format__name', r'[^/]+'))
 
     def list(self, request, *args, **kwargs):
         """
@@ -462,7 +465,7 @@ class BuildImageRTTTestsViewSet(pdc_viewsets.StrictQueryParamMixin,
         __Method__:
         GET
 
-        __URL__: $LINK:buildimagertttests-detail:instance_pk$
+        __URL__: $LINK:buildimagertttests-detail:build_nvr}/{image_format$
 
         __Response__:
 
@@ -492,7 +495,7 @@ class BuildImageRTTTestsViewSet(pdc_viewsets.StrictQueryParamMixin,
 
         __Method__: PATCH
 
-        __URL__: $LINK:buildimagertttests-detail:instance_pk$
+        __URL__: $LINK:buildimagertttests-detail:build_nvr}/{image_format$
 
         __Data__:
 


### PR DESCRIPTION
Update or retrieve the build-image-rtt-tests api with
build_nvr/format instead of ID.

JIRA: PDC-1248