### PR TITLE
Add response info for composes/{compose_id}/rpm-mapping/{package}

### DIFF
--- a/pdc/apps/compose/views.py
+++ b/pdc/apps/compose/views.py
@@ -761,6 +761,18 @@ class ComposeRPMMappingView(StrictQueryParamMixin,
         """
         __URL__: $LINK:composerpmmapping-detail:compose_id:package$
 
+        __Response__:
+
+            {
+                Variants:{
+                    archs:{
+                        rpm_names:[
+                            rpm_arch,
+                        ]
+                    }
+                }
+            }
+
         Returns a JSON representing the RPM mapping. There is an optional query
         parameter `?disable_overrides=1` which returns the raw mapping not
         affected by any overrides.
@@ -805,6 +817,19 @@ class ComposeRPMMappingView(StrictQueryParamMixin,
         containing new mapping. PDC will compute changes between current
         mapping and the requested one. The response contains a list of changes
         suitable for partial update via `PATCH` method.
+
+        __Response__:
+
+            {
+                'release_id':       <str>,
+                'srpm_name':        <str>,
+                'action':           <str>,
+                'variant':          <str>,
+                'arch':             <str>,
+                'rpm_name':         <str>,
+                'rpm_arch':         <str>,
+                'include':          <bool>,
+            }
 
         By default, no changes are performed on the server. If you add
         `?perform=1` query string parameter, the changes will actually be saved

--- a/pdc/apps/release/lib.py
+++ b/pdc/apps/release/lib.py
@@ -68,10 +68,10 @@ def get_or_create_integrated_release(request, orig_release, release):
             product_version=integrated_product_version
         )
     except ValidationError:
-        msg = ('Failed to create release {}-{}-{} for integrated layered product.'
-               + ' A conflicting release already exists.'
-               + ' There is likely a version mismatch between the imported'
-               + ' release and its layered integrated product in the composeinfo.')
+        msg = ('Failed to create release {}-{}-{} for integrated layered product.' +
+               ' A conflicting release already exists.' +
+               ' There is likely a version mismatch between the imported' +
+               ' release and its layered integrated product in the composeinfo.')
         raise ValidationError(
             msg.format(release.short.lower(), release.version, integrated_base_product.base_product_id)
         )

--- a/pdc/apps/repository/tests.py
+++ b/pdc/apps/repository/tests.py
@@ -311,10 +311,10 @@ class RepositoryMultipleFilterTestCase(APITestCase):
         self.assertEqual(response.data['count'], 2 * 27)
 
     def test_multiple_combination(self):
-        query = ('?service=pulp&service=ftp'
-                 + '&repo_family=beta&repo_family=htb'
-                 + '&content_format=rpm&content_format=iso'
-                 + '&content_category=debug&content_category=binary')
+        query = ('?service=pulp&service=ftp' +
+                 '&repo_family=beta&repo_family=htb' +
+                 '&content_format=rpm&content_format=iso' +
+                 '&content_category=debug&content_category=binary')
         response = self.client.get(reverse('repo-list') + query)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 16)


### PR DESCRIPTION
There is not response formate in docs of retrieve and update
method in composes/{compose_id}/rpm-mapping/{package}.

JIRA: PDC_1257