### PR TITLE
Improve output when successfully import files composeinfo.json/rpm-manifest.json/image-manifest.json

### DIFF
--- a/pdc/apps/compose/lib.py
+++ b/pdc/apps/compose/lib.py
@@ -169,6 +169,8 @@ def compose__import_rpms(request, release_id, composeinfo, rpm_manifest):
                               'num_linked_rpms': imported_rpms,
                           }))
 
+    return compose_obj.compose_id, imported_rpms
+
 
 @transaction.atomic
 def compose__import_images(request, release_id, composeinfo, image_manifest):
@@ -249,6 +251,8 @@ def compose__import_images(request, release_id, composeinfo, image_manifest):
                               'compose': compose_obj.compose_id,
                               'num_linked_images': imported_images,
                           }))
+
+    return compose_obj.compose_id, imported_images
 
 
 def _find_composes_srpm_name_with_rpm_nvr(nvr):

--- a/pdc/apps/compose/tests.py
+++ b/pdc/apps/compose/tests.py
@@ -734,12 +734,23 @@ class ComposeRPMViewAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
                                      'composeinfo': self.compose_info},
                                     format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data.get('compose'), 'TP-1.0-20150310.0')
+        self.assertEqual(response.data.get('imported rpms'), 6)
         self.assertNumChanges([11, 5])
         self.assertEqual(models.ComposeRPM.objects.count(), 6)
         response = self.client.get(reverse('composerpm-detail', args=['TP-1.0-20150310.0']))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(dict(response.data),
                              self.manifest)
+
+        response = self.client.post(reverse('composerpm-list'),
+                                    {'rpm_manifest': self.manifest,
+                                     'release_id': 'tp-1.0',
+                                     'composeinfo': self.compose_info},
+                                    format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data.get('compose'), 'TP-1.0-20150310.0')
+        self.assertEqual(response.data.get('imported rpms'), 6)
 
 
 class ComposeImageAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
@@ -774,11 +785,22 @@ class ComposeImageAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
                                      'composeinfo': self.compose_info},
                                     format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data.get('compose'), 'TP-1.0-20150310.0')
+        self.assertEqual(response.data.get('imported images'), 4)
         self.assertNumChanges([11, 5])
         self.assertEqual(models.ComposeImage.objects.count(), 4)
         response = self.client.get(reverse('image-list'), {'compose': 'TP-1.0-20150310.0'})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('count'), 4)
+
+        response = self.client.post(reverse('composeimage-list'),
+                                    {'image_manifest': self.manifest,
+                                     'release_id': 'tp-1.0',
+                                     'composeinfo': self.compose_info},
+                                    format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data.get('compose'), 'TP-1.0-20150310.0')
+        self.assertEqual(response.data.get('imported images'), 4)
 
     def test_import_inconsistent_data(self):
         self.manifest['payload']['compose']['id'] = 'TP-1.0-20150315.0'

--- a/pdc/apps/compose/views.py
+++ b/pdc/apps/compose/views.py
@@ -669,6 +669,12 @@ class ComposeRPMView(StrictQueryParamMixin, viewsets.GenericViewSet):
                 "rpm_manifest": rpm_manifest
             }
 
+        __Response__:
+            {
+                "compose_id": string,
+                "imported rpms": int
+            }
+
         The `composeinfo` and `rpm_manifest` values should be actual JSON
         representation of composeinfo and rpm manifest, as stored in
         `composeinfo.json` and `rpm-manifest.json` files.
@@ -700,8 +706,8 @@ class ComposeRPMView(StrictQueryParamMixin, viewsets.GenericViewSet):
                 errors[key] = ["This field is required"]
         if errors:
             return Response(status=status.HTTP_400_BAD_REQUEST, data=errors)
-        lib.compose__import_rpms(request, data['release_id'], data['composeinfo'], data['rpm_manifest'])
-        return Response(status=status.HTTP_201_CREATED)
+        compose_id, imported_rpms = lib.compose__import_rpms(request, data['release_id'], data['composeinfo'], data['rpm_manifest'])
+        return Response(data={'compose': compose_id, 'imported rpms': imported_rpms}, status=status.HTTP_201_CREATED)
 
     def retrieve(self, request, **kwargs):
         """
@@ -866,6 +872,12 @@ class ComposeImageView(StrictQueryParamMixin,
                 "image_manifest": image_manifest
             }
 
+        __Response__:
+            {
+                "compose_id": string,
+                "imported images": int
+            }
+
         The `composeinfo` and `image_manifest` values should be actual JSON
         representation of composeinfo and image manifest, as stored in
         `composeinfo.json` and `image-manifest.json` files.
@@ -885,8 +897,8 @@ class ComposeImageView(StrictQueryParamMixin,
                 errors[key] = ["This field is required"]
         if errors:
             return Response(status=400, data=errors)
-        lib.compose__import_images(request, data['release_id'], data['composeinfo'], data['image_manifest'])
-        return Response(status=201)
+        compose_id, imported_images = lib.compose__import_images(request, data['release_id'], data['composeinfo'], data['image_manifest'])
+        return Response(data={'compose': compose_id, 'imported images': imported_images}, status=status.HTTP_201_CREATED)
 
     def retrieve(self, request, **kwargs):
         """

--- a/pdc/apps/release/lib.py
+++ b/pdc/apps/release/lib.py
@@ -170,3 +170,5 @@ def release__import_from_composeinfo(request, composeinfo_json):
 
     for obj in add_to_changelog:
         _maybe_log(request, True, obj)
+
+    return release_obj

--- a/pdc/apps/release/tests.py
+++ b/pdc/apps/release/tests.py
@@ -1329,6 +1329,7 @@ class ReleaseImportTestCase(TestCaseWithChangeSetMixin, APITestCase):
             data = json.loads(f.read())
         response = self.client.post(reverse('releaseimportcomposeinfo-list'), data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data.get('url'), '/rest_api/v1/releases/tp-1.0/')
         self.assertNumChanges([11])
         self.assertEqual(models.Product.objects.count(), 2)
         self.assertEqual(models.ProductVersion.objects.count(), 2)
@@ -1376,6 +1377,10 @@ class ReleaseImportTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertItemsEqual(release.trees, ['Server-SAP.x86_64'])
         self.assertEqual(release.variant_set.get(variant_uid='Server-SAP').integrated_to.release_id,
                          'tp-1.0')
+
+        response = self.client.post(reverse('releaseimportcomposeinfo-list'), data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data.get('url'), '/rest_api/v1/releases/tp-1.0/')
 
     def test_import_via_get(self):
         data = {'garbage': 'really'}

--- a/pdc/apps/release/views.py
+++ b/pdc/apps/release/views.py
@@ -437,6 +437,11 @@ class ReleaseImportView(StrictQueryParamMixin, viewsets.GenericViewSet):
         formatting of the file is not important for PDC, and it is possible to
         significantly minimize size of the file by removing indentation)
 
+        __Response__:
+            {
+                "url": string
+            }
+
         __Example__:
 
             $ curl -H 'Content-Type: application/json' -X POST -d @/path/to/composeinfo.json \\
@@ -444,8 +449,9 @@ class ReleaseImportView(StrictQueryParamMixin, viewsets.GenericViewSet):
         """
         if not request.data:
             return Response(status=status.HTTP_400_BAD_REQUEST, data={'detail': 'Missing composeinfo'})
-        lib.release__import_from_composeinfo(request, request.data)
-        return Response(status=status.HTTP_201_CREATED)
+        release_obj = lib.release__import_from_composeinfo(request, request.data)
+        url = reverse('release-detail', args=[release_obj])
+        return Response({'url': url}, status=status.HTTP_201_CREATED)
 
 
 class BaseProductViewSet(ChangeSetCreateModelMixin,


### PR DESCRIPTION
1. Return count of the images/rpms when importing image-manifes and rpm-manifest.
2. Return url when importing release from composeinfo.json

JIRA: PDC-1268