### PR TITLE
Provide a response header field name "PDC-Warning"

### DIFF
--- a/pdc/apps/common/constants.py
+++ b/pdc/apps/common/constants.py
@@ -18,3 +18,6 @@ DEVEL_CONTACT = 'Devel_Owner'
 
 # Arch type
 ARCH_SRC = 'src'
+
+# PDC warning field in response header
+PDC_WARNING_HEADER_NAME = 'pdc-warning'

--- a/pdc/apps/common/viewsets.py
+++ b/pdc/apps/common/viewsets.py
@@ -17,6 +17,8 @@ from contrib import drf_introspection
 from rest_framework import mixins, status, viewsets
 from rest_framework.response import Response
 
+from pdc.apps.utils.utils import generate_warning_header_dict
+
 
 class NoSetattrInPreSaveMixin(object):
     """
@@ -70,7 +72,8 @@ class NoEmptyPatchMixin(object):
         """
         return Response(
             status=status.HTTP_400_BAD_REQUEST,
-            data=settings.EMPTY_PATCH_ERROR_RESPONSE
+            data=settings.EMPTY_PATCH_ERROR_RESPONSE,
+            headers=generate_warning_header_dict(settings.EMPTY_PATCH_ERROR_RESPONSE['detail'])
         )
 
 

--- a/pdc/apps/component/views.py
+++ b/pdc/apps/component/views.py
@@ -20,6 +20,7 @@ from rest_framework.response import Response
 from pdc.apps.common import viewsets
 from pdc.apps.common.models import Label
 from pdc.apps.common.serializers import LabelSerializer, StrictSerializerMixin
+from pdc.apps.utils.utils import generate_warning_header_dict
 from pdc.apps.common.filters import LabelFilter
 from .models import (GlobalComponent,
                      ReleaseComponent,
@@ -929,7 +930,8 @@ class BugzillaComponentViewSet(viewsets.PDCModelViewSet):
             headers = self.get_success_headers(serializer.data)
             return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
         else:
-            return Response(serializer.data, status=status.HTTP_200_OK)
+            return Response(serializer.data, status=status.HTTP_200_OK,
+                            headers=generate_warning_header_dict("The bugzilla component already exists"))
 
     def destroy(self, request, *args, **kwargs):
         """

--- a/pdc/apps/compose/tests.py
+++ b/pdc/apps/compose/tests.py
@@ -16,6 +16,7 @@ from rest_framework import status
 
 from pdc.apps.bindings import models as binding_models
 from pdc.apps.common.test_utils import create_user, TestCaseWithChangeSetMixin
+from pdc.apps.common.constants import PDC_WARNING_HEADER_NAME
 from pdc.apps.release.models import Release, ProductVersion
 from pdc.apps.component.models import (ReleaseComponent,
                                        BugzillaComponent)
@@ -489,6 +490,9 @@ class ComposeUpdateTestCase(TestCaseWithChangeSetMixin, APITestCase):
         response = self.client.patch(reverse('compose-detail', args=['compose-1']),
                                      {}, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        # check response header
+        self.assertEqual(response._headers[PDC_WARNING_HEADER_NAME.lower()],
+                         (PDC_WARNING_HEADER_NAME, 'Partial update with no changes does not make much sense.'))
 
     def test_patch_linked_releases_not_a_list(self):
         response = self.client.patch(reverse('compose-detail', args=['compose-1']),

--- a/pdc/apps/utils/utils.py
+++ b/pdc/apps/utils/utils.py
@@ -4,6 +4,7 @@
 # http://opensource.org/licenses/MIT
 #
 from pdc.apps.common.hacks import validate_model
+from pdc.apps.common.constants import PDC_WARNING_HEADER_NAME
 from django.db.models.signals import pre_save
 from django.forms.models import model_to_dict
 
@@ -24,3 +25,7 @@ def group_obj_export(group_obj, fields=None):
 def urldecode(url):
     """Decode %7B/%7D to {}."""
     return url.replace('%7B', '{').replace('%7D', '}')
+
+
+def generate_warning_header_dict(msg):
+    return {PDC_WARNING_HEADER_NAME: msg}


### PR DESCRIPTION
Warning could be put into this field. Currently, it is
added into the response from NoEmptyPatchMixin when
patch or update with empty data.

JIRA: PDC-1283