### PR TITLE
Return error info When srouce release doesn't contain component

### DIFF
--- a/pdc/apps/component/tests.py
+++ b/pdc/apps/component/tests.py
@@ -1198,7 +1198,7 @@ class ReleaseCloneWithComponentsTestCase(TestCaseWithChangeSetMixin, APITestCase
                                     {'source_release_id': resource_release_id,
                                      'target_release_id': 'release-1.0'},
                                     format='json')
-        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_release_component_clone_with_error_target_release(self):
         response = self.client.post(reverse('releasecomponentclone-list'),

--- a/pdc/apps/release/views.py
+++ b/pdc/apps/release/views.py
@@ -666,8 +666,8 @@ class ReleaseComponentCloneViewSet(StrictQueryParamMixin, viewsets.GenericViewSe
             "url": [the link for target release component]
             }
 
-        If the source-release doesn't contains components, which will return
-        400  {'detail': 'there is no component in source release'}.
+        Please make sure source release contains components,
+        cloning source release without components doesn't make much sense.
 
         If `component_dist_git_branch` is present, the value will be set for all
         release components under the target release. If missing, release

--- a/pdc/apps/release/views.py
+++ b/pdc/apps/release/views.py
@@ -659,10 +659,15 @@ class ReleaseComponentCloneViewSet(StrictQueryParamMixin, viewsets.GenericViewSe
                 "component_dist_git_branch":    string,     # optional
                 "include_inactive":             bool,       # optional
             }
+
         __Response__:
+
             {
             "url": [the link for target release component]
             }
+
+        If the source-release doesn't contains components, which will return
+        400  {'detail': 'there is no component in source release'}.
 
         If `component_dist_git_branch` is present, the value will be set for all
         release components under the target release. If missing, release
@@ -691,9 +696,10 @@ class ReleaseComponentCloneViewSet(StrictQueryParamMixin, viewsets.GenericViewSe
         except Http404:
             return Response({'detail': 'Target_release %s is not existed' % target_release_id},
                             status=status.HTTP_404_NOT_FOUND)
+
         if source_release.releasecomponent_set.count() == 0:
             return Response({'detail': 'there is no component in source release'},
-                            status=status.HTTP_204_NO_CONTENT)
+                            status=status.HTTP_400_BAD_REQUEST)
         if not target_release.active:
             return Response({'detail': 'can\'t clone components ' +
                                        'to an inactive target release %s' % target_release_id},


### PR DESCRIPTION
For rpc/release/component-clone, when source-release doesn't contain
component, return error info for user.

JIRA: PDC-1282