### PR TITLE
Improve ordering releases, product versions and products.

### DIFF
--- a/pdc/apps/release/migrations/0003_auto_20160209_1206.py
+++ b/pdc/apps/release/migrations/0003_auto_20160209_1206.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('release', '0002_auto_20150512_0719'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='product',
+            options={'ordering': ('short',)},
+        ),
+        migrations.AlterModelOptions(
+            name='productversion',
+            options={'ordering': ('product_version_id',)},
+        ),
+    ]

--- a/pdc/apps/release/models.py
+++ b/pdc/apps/release/models.py
@@ -67,6 +67,9 @@ class Product(models.Model):
     short = models.CharField(max_length=200, unique=True, validators=[
         RegexValidator(regex=r"^[a-z\-]+$", message='Only accept lowercase letter or -')])
 
+    class Meta:
+        ordering = ("short", )
+
     def __unicode__(self):
         return self.short
 
@@ -107,6 +110,7 @@ class ProductVersion(models.Model):
 
     class Meta:
         unique_together = (("short", "version"))
+        ordering = ("product_version_id", )
 
     def __unicode__(self):
         return self.product_version_id

--- a/pdc/apps/release/templates/base_product_list_include.html
+++ b/pdc/apps/release/templates/base_product_list_include.html
@@ -11,7 +11,7 @@
   <tbody>
 {% for base_product in base_product_list %}
   <tr>
-    <td><a href="{% url "base_product/detail" base_product.id %}">{{ base_product.id }}</a></td>
+    <td><a href="{% url "base_product/detail" base_product.id %}">{{ base_product }}</a></td>
     <td>{{ base_product.name }}</td>
     <td>{{ base_product.short }}</td>
     <td>{{ base_product.version }}</td>

--- a/pdc/apps/release/views.py
+++ b/pdc/apps/release/views.py
@@ -32,7 +32,7 @@ from . import lib
 
 class ReleaseListView(SearchView):
     form_class = ReleaseSearchForm
-    queryset = models.Release.objects.select_related('release_type', 'product_version', 'base_product').order_by('id')
+    queryset = models.Release.objects.select_related('release_type', 'product_version', 'base_product')
     allow_empty = True
     template_name = "release_list.html"
     context_object_name = "release_list"
@@ -57,7 +57,7 @@ class ReleaseDetailView(DetailView):
 
 class BaseProductListView(SearchView):
     form_class = BaseProductSearchForm
-    queryset = models.BaseProduct.objects.all().order_by('id')
+    queryset = models.BaseProduct.objects.all()
     allow_empty = True
     template_name = "base_product_list.html"
     context_object_name = "base_product_list"
@@ -80,7 +80,7 @@ class BaseProductDetailView(DetailView):
 
 class ProductListView(SearchView):
     form_class = ProductSearchForm
-    queryset = models.Product.objects.prefetch_related('productversion_set__release_set').order_by('id')
+    queryset = models.Product.objects.prefetch_related('productversion_set__release_set')
     allow_empty = True
     template_name = "product_list.html"
     context_object_name = "product_list"
@@ -107,7 +107,7 @@ class ProductViewSet(ChangeSetCreateModelMixin,
     the form of `product_version_id` (both in requests and responses).
     """
 
-    queryset = models.Product.objects.prefetch_related('productversion_set').order_by('id')
+    queryset = models.Product.objects.prefetch_related('productversion_set')
     serializer_class = ProductSerializer
     lookup_field = 'short'
     filter_class = filters.ProductFilter
@@ -190,7 +190,7 @@ class ProductVersionViewSet(ChangeSetCreateModelMixin,
     `short` name. Similarly releases are referenced by `release_id`. This
     applies to both requests and responses.
     """
-    queryset = models.ProductVersion.objects.select_related('product').prefetch_related('release_set').order_by('id')
+    queryset = models.ProductVersion.objects.select_related('product').prefetch_related('release_set')
     serializer_class = ProductVersionSerializer
     lookup_field = 'product_version_id'
     lookup_value_regex = '[^/]+'
@@ -463,7 +463,7 @@ class BaseProductViewSet(ChangeSetCreateModelMixin,
     """
     An API endpoint providing access to base products.
     """
-    queryset = models.BaseProduct.objects.all().order_by('id')
+    queryset = models.BaseProduct.objects.all()
     serializer_class = BaseProductSerializer
     lookup_field = 'base_product_id'
     lookup_value_regex = '[^/]+'
@@ -532,7 +532,7 @@ class BaseProductViewSet(ChangeSetCreateModelMixin,
 
 class ProductVersionListView(SearchView):
     form_class = ProductVersionSearchForm
-    queryset = models.ProductVersion.objects.prefetch_related('release_set').order_by('id')
+    queryset = models.ProductVersion.objects.prefetch_related('release_set')
     allow_empty = True
     template_name = "product_version_list.html"
     context_object_name = "product_version_list"
@@ -782,7 +782,7 @@ class ReleaseTypeViewSet(StrictQueryParamMixin,
     -d _data_ (a json string). or GUI plugins for
     browsers, such as ``RESTClient``, ``RESTConsole``.
     """
-    queryset = models.ReleaseType.objects.all().order_by('id')
+    queryset = models.ReleaseType.objects.all()
     serializer_class = ReleaseTypeSerializer
     filter_class = filters.ReleaseTypeFilter
 
@@ -830,7 +830,7 @@ class ReleaseVariantViewSet(ChangeSetModelMixin,
     `release_id/variant_uid` is used in URL for retrieving, updating or
     deleting a single variant as well as in bulk operations.
     """
-    queryset = models.Variant.objects.all().order_by('id')
+    queryset = models.Variant.objects.all()
     serializer_class = ReleaseVariantSerializer
     filter_class = filters.ReleaseVariantFilter
     lookup_fields = (('release__release_id', r'[^/]+'), ('variant_uid', r'[^/]+'))
@@ -966,7 +966,7 @@ class VariantTypeViewSet(StrictQueryParamMixin,
     API endpoint that allows variant_types to be viewed.
     """
     serializer_class = VariantTypeSerializer
-    queryset = models.VariantType.objects.all().order_by('id')
+    queryset = models.VariantType.objects.all()
 
     def list(self, request, *args, **kwargs):
         """


### PR DESCRIPTION
All objects were ordered by ID which was confusing for WebUI users.
Everything is now ordered by pretty IDs (e.g. release_id).