### PR TITLE
Add more detail error info for compose-tree-locations

### DIFF
--- a/pdc/apps/compose/serializers.py
+++ b/pdc/apps/compose/serializers.py
@@ -147,6 +147,8 @@ class ComposeTreeSerializer(StrictSerializerMixin,
 
         if compose == variant.compose and arch in variant.arches:
             return attrs
+        elif compose == variant.compose and arch not in variant.arches:
+            raise serializers.ValidationError('Arch %s does not exist in given compose/variant branch' % arch)
         else:
             raise serializers.ValidationError('The combination with compose %s, variant %s, arch %s does not exist' %
                                               (compose, variant, arch))

--- a/pdc/apps/contact/views.py
+++ b/pdc/apps/contact/views.py
@@ -542,7 +542,7 @@ class _BaseContactViewSet(viewsets.PDCModelViewSet):
     def update(self, *args, **kwargs):
         """Change details about a contact linked to component.
 
-        Please not that if you change the `contact` field here, only the single
+        Please note that if you change the `contact` field here, only the single
         updated relationship between contact and component will be updated.
         Specifically, no other component will be affected.
 


### PR DESCRIPTION
When Arch para exist in data but doesn't exist in given
compose/variant branch, return detail error info.

JIRA: PDC-1232