### PR TITLE
Remove deprecated API /rpc/compose/import-images/

### DIFF
--- a/pdc/apps/compose/routers.py
+++ b/pdc/apps/compose/routers.py
@@ -15,9 +15,6 @@ router.register(r'composes/(?P<compose_id>[^/]+)/rpm-mapping',
                 base_name='composerpmmapping')
 router.register(r'compose-rpms', views.ComposeRPMView)
 router.register(r'compose-images', views.ComposeImageView)
-router.register(r'rpc/compose/import-images',
-                views.ComposeImportImagesView,
-                base_name='composeimportimages')
 
 router.register('overrides/rpm',
                 views.ReleaseOverridesRPMViewSet,

--- a/pdc/apps/compose/tests.py
+++ b/pdc/apps/compose/tests.py
@@ -768,20 +768,6 @@ class ComposeImageAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
         # Caching ids makes it faster, but the cache needs to be cleared for each test.
         models.Path.CACHE = {}
 
-    def test_import_images_by_deprecated_api(self):
-        # TODO: remove this test after next release
-        response = self.client.post(reverse('composeimportimages-list'),
-                                    {'image_manifest': self.manifest,
-                                     'release_id': 'tp-1.0',
-                                     'composeinfo': self.compose_info},
-                                    format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertNumChanges([11, 5])
-        self.assertEqual(models.ComposeImage.objects.count(), 4)
-        response = self.client.get(reverse('image-list'), {'compose': 'TP-1.0-20150310.0'})
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data.get('count'), 4)
-
     def test_import_images(self):
         response = self.client.post(reverse('composeimage-list'),
                                     {'image_manifest': self.manifest,

--- a/pdc/apps/compose/views.py
+++ b/pdc/apps/compose/views.py
@@ -971,25 +971,6 @@ class ComposeImageView(StrictQueryParamMixin,
         return Response(manifest.serialize({}))
 
 
-class ComposeImportImagesView(StrictQueryParamMixin, viewsets.GenericViewSet):
-    # TODO: remove this class after next release
-    queryset = ComposeImage.objects.none()  # Required for permissions
-
-    def create(self, request):
-        """
-        This end-point is deprecated. Use $LINK:composeimage-list$ instead.
-        """
-        data = request.data
-        errors = {}
-        for key in ('release_id', 'composeinfo', 'image_manifest'):
-            if key not in data:
-                errors[key] = ["This field is required"]
-        if errors:
-            return Response(status=400, data=errors)
-        lib.compose__import_images(request, data['release_id'], data['composeinfo'], data['image_manifest'])
-        return Response(status=201)
-
-
 class ReleaseOverridesRPMViewSet(StrictQueryParamMixin,
                                  mixins.ListModelMixin,
                                  ChangeSetCreateModelMixin,


### PR DESCRIPTION
This API was claimed deprecated in 0.6.0 (PDC-911)

JIRA: PDC-1370