### PR TITLE
Add subvariant field to images

### DIFF
--- a/pdc/apps/compose/fixtures/tests/image-manifest.json
+++ b/pdc/apps/compose/fixtures/tests/image-manifest.json
@@ -28,7 +28,8 @@
                         "path": "Client/source/iso/TP-1.0-20150310.0-Client-source-dvd1.iso",
                         "size": 4696397824,
                         "type": "dvd",
-                        "volume_id": "TP-1.0 Client.src"
+                        "volume_id": "TP-1.0 Client.src",
+                        "subvariant": "Client"
                     }
                 ]
             },
@@ -50,7 +51,8 @@
                         "path": "Server/ppc64/iso/TP-1.0-20150310.0-Server-ppc64-boot.iso",
                         "size": 397934592,
                         "type": "boot",
-                        "volume_id": "TP_1_0_ppc64"
+                        "volume_id": "TP_1_0_ppc64",
+                        "subvariant": null
                     }
                 ],
                 "s390x": [
@@ -70,7 +72,8 @@
                         "path": "Server/s390x/iso/TP-1.0-20150310.0-Server-s390x-dvd1.iso",
                         "size": 2560704512,
                         "type": "dvd",
-                        "volume_id": "TP-1.0 Server.s390x"
+                        "volume_id": "TP-1.0 Server.s390x",
+                        "subvariant": null
                     }
                 ]
             },
@@ -92,7 +95,8 @@
                         "path": "Server-SAP/source/iso/SAP-1.0-TP-1-20150310.0-Server-source-dvd1.iso",
                         "size": 2156544,
                         "type": "dvd",
-                        "volume_id": "SAP-1.0 TP-1 Server.src"
+                        "volume_id": "SAP-1.0 TP-1 Server.src",
+                        "subvariant": null
                     }
                 ]
             }

--- a/pdc/apps/compose/lib.py
+++ b/pdc/apps/compose/lib.py
@@ -243,6 +243,7 @@ def compose__import_images(request, release_id, composeinfo, image_manifest):
                         'volume_id': i.volume_id,
                         'md5': i.checksums.get("md5", None),
                         'sha1': i.checksums.get("sha1", None),
+                        'subvariant': getattr(i, 'subvariant', None),
                     }
                 )
 

--- a/pdc/apps/compose/views.py
+++ b/pdc/apps/compose/views.py
@@ -1075,6 +1075,7 @@ class ComposeImageView(StrictQueryParamMixin,
             im.disc_number = cimage.image.disc_number
             im.disc_count = cimage.image.disc_count
             im.checksums = {'sha256': cimage.image.sha256}
+            im.subvariant = cimage.image.subvariant
             if cimage.image.md5:
                 im.checksums['md5'] = cimage.image.md5
             if cimage.image.sha1:

--- a/pdc/apps/package/migrations/0012_image_payload.py
+++ b/pdc/apps/package/migrations/0012_image_payload.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('package', '0011_auto_20160219_0915'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='image',
+            name='subvariant',
+            field=models.CharField(max_length=4096, null=True, blank=True),
+        ),
+    ]

--- a/pdc/apps/package/models.py
+++ b/pdc/apps/package/models.py
@@ -269,6 +269,7 @@ class Image(models.Model):
     md5                 = models.CharField(max_length=32, null=True, blank=True, validators=[validate_md5])
     sha1                = models.CharField(max_length=40, null=True, blank=True, validators=[validate_sha1])
     sha256              = models.CharField(max_length=64, validators=[validate_sha256])
+    subvariant          = models.CharField(max_length=4096, null=True, blank=True)
 
     class Meta:
         unique_together = (


### PR DESCRIPTION
Productmd has merged a patch that add an extra field `subvariant` to image manifest. This in turn broke PDC test suite. This patch should update PDC to be able to store and return that value.