### PR TITLE
Productmd changes

### DIFF
--- a/pdc/apps/release/fixtures/tests/base_product.json
+++ b/pdc/apps/release/fixtures/tests/base_product.json
@@ -6,7 +6,8 @@
             "base_product_id": "product-1",
             "short": "product",
             "version": "1",
-            "name": "Our awesome product"
+            "name": "Our awesome product",
+            "release_type": 1
         }
     }
 ]

--- a/pdc/apps/release/migrations/0004_auto_20160308_1614.py
+++ b/pdc/apps/release/migrations/0004_auto_20160308_1614.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('release', '0003_auto_20160209_1206'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='baseproduct',
+            name='short',
+            field=models.CharField(max_length=200, validators=[django.core.validators.RegexValidator(regex=b'^[a-z]+([a-z0-9]*-?[a-z0-9]+)*$', message=b'Only accept lowercase letters, numbers or -')]),
+        ),
+        migrations.AlterField(
+            model_name='product',
+            name='short',
+            field=models.CharField(unique=True, max_length=200, validators=[django.core.validators.RegexValidator(regex=b'^[a-z]+([a-z0-9]*-?[a-z0-9]+)*$', message=b'Only accept lowercase letters, numbers or -')]),
+        ),
+        migrations.AlterField(
+            model_name='productversion',
+            name='short',
+            field=models.CharField(max_length=200, validators=[django.core.validators.RegexValidator(regex=b'^[a-z]+([a-z0-9]*-?[a-z0-9]+)*$', message=b'Only accept lowercase letters, numbers or -')]),
+        ),
+        migrations.AlterField(
+            model_name='productversion',
+            name='version',
+            field=models.CharField(max_length=200, validators=[django.core.validators.RegexValidator(regex=b'^([^0-9].*|([0-9]+(\\.?[0-9]+)*))$', message=b'Only accept comma separated numbers or any text')]),
+        ),
+        migrations.AlterField(
+            model_name='release',
+            name='short',
+            field=models.CharField(max_length=200, validators=[django.core.validators.RegexValidator(regex=b'^[a-z]+([a-z0-9]*-?[a-z0-9]+)*$', message=b'Only accept lowercase letters, numbers or -')]),
+        ),
+        migrations.AlterField(
+            model_name='release',
+            name='version',
+            field=models.CharField(max_length=200, validators=[django.core.validators.RegexValidator(regex=b'^([^0-9].*|([0-9]+(\\.?[0-9]+)*))$', message=b'Only accept comma separated numbers or any text')]),
+        ),
+    ]

--- a/pdc/apps/release/migrations/0005_auto_20160314_1532.py
+++ b/pdc/apps/release/migrations/0005_auto_20160314_1532.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+from productmd.common import create_release_id
+
+
+def set_baseproduct_id(obj):
+    obj.base_product_id = create_release_id(obj.short.lower(), obj.version, obj.release_type.short)
+
+
+def set_release_id(obj):
+    bp_dict = {}
+    if obj.base_product:
+        bp_dict = {
+            "bp_short": obj.base_product.short.lower(),
+            "bp_version": obj.base_product.version,
+            "bp_type": obj.base_product.release_type.short,
+        }
+    obj.release_id = create_release_id(obj.short.lower(), obj.version, obj.release_type.short, **bp_dict)
+
+
+def populate_baseproduct_release_type(apps, schema_editor):
+    release_type_model = apps.get_model('release', 'BaseProduct')
+    try:
+        release_type = release_type_model.objects.get(name="ga")
+    except release_type_model.DoesNotExist:
+        return
+    model = apps.get_model('release', 'BaseProduct')
+    for i in model.objects.all():
+        i.type = release_type
+        # re-generate base_product_id to the new format
+        set_base_product_id(i)
+        i.save()
+
+
+def create_new_release_id(apps, schema_editor):
+    model = apps.get_model('release', 'Release')
+    for i in model.objects.all():
+        # re-generate release_id to the new format
+        set_release_id(i)
+        i.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('release', '0004_auto_20160308_1614'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='baseproduct',
+            name='release_type',
+            field=models.ForeignKey(default=1, to='release.ReleaseType'),
+            preserve_default=False,
+        ),
+        migrations.AlterUniqueTogether(
+            name='baseproduct',
+            unique_together=set([('name', 'version', 'release_type'), ('short', 'version', 'release_type')]),
+        ),
+        migrations.RunPython(populate_baseproduct_release_type),
+        migrations.RunPython(create_new_release_id),
+    ]

--- a/pdc/apps/release/models.py
+++ b/pdc/apps/release/models.py
@@ -13,6 +13,8 @@ from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from django.core.exceptions import ValidationError
 
+from productmd.common import RELEASE_SHORT_RE, RELEASE_VERSION_RE
+
 from pdc.apps.common.hacks import as_list
 from . import signals
 
@@ -30,7 +32,7 @@ class BaseProduct(models.Model):
     # base_product_id is populated by populate_base_product_id() pre_save hook
     base_product_id     = models.CharField(max_length=200, blank=False, unique=True)
     short = models.CharField(max_length=200, validators=[
-        RegexValidator(regex=r"^[a-z\-]+$", message='Only accept lowercase letter or -')])
+        RegexValidator(regex=RELEASE_SHORT_RE.pattern, message='Only accept lowercase letters, numbers or -')])
     version             = models.CharField(max_length=200)
     name                = models.CharField(max_length=255)
 
@@ -65,7 +67,7 @@ def populate_base_product_id(sender, instance, **kwargs):
 class Product(models.Model):
     name    = models.CharField(max_length=200)
     short = models.CharField(max_length=200, unique=True, validators=[
-        RegexValidator(regex=r"^[a-z\-]+$", message='Only accept lowercase letter or -')])
+        RegexValidator(regex=RELEASE_SHORT_RE.pattern, message='Only accept lowercase letters, numbers or -')])
 
     class Meta:
         ordering = ("short", )
@@ -103,8 +105,9 @@ class Product(models.Model):
 class ProductVersion(models.Model):
     name                = models.CharField(max_length=200)
     short = models.CharField(max_length=200, validators=[
-        RegexValidator(regex=r"^[a-z\-]+$", message='Only accept lowercase letter or -')])
-    version             = models.CharField(max_length=200)
+        RegexValidator(regex=RELEASE_SHORT_RE.pattern, message='Only accept lowercase letters, numbers or -')])
+    version             = models.CharField(max_length=200, validators=[
+        RegexValidator(regex=RELEASE_VERSION_RE.pattern, message='Only accept comma separated numbers or any text')])
     product             = models.ForeignKey(Product)
     product_version_id  = models.CharField(max_length=200)
 
@@ -149,8 +152,9 @@ class Release(models.Model):
     # release_id is populated by populate_release_id() pre_save hook
     release_id          = models.CharField(max_length=200, blank=False, unique=True)
     short = models.CharField(max_length=200, blank=False, validators=[
-        RegexValidator(regex=r"^[a-z\-]+$", message='Only accept lowercase letter or -')])
-    version             = models.CharField(max_length=200, blank=False)
+        RegexValidator(regex=RELEASE_SHORT_RE.pattern, message='Only accept lowercase letters, numbers or -')])
+    version             = models.CharField(max_length=200, blank=False, validators=[
+        RegexValidator(regex=RELEASE_VERSION_RE.pattern, message='Only accept comma separated numbers or any text')])
     name                = models.CharField(max_length=255, blank=False)
     release_type        = models.ForeignKey(ReleaseType, blank=False, db_index=True)
     base_product        = models.ForeignKey(BaseProduct, null=True, blank=True)

--- a/pdc/apps/release/serializers.py
+++ b/pdc/apps/release/serializers.py
@@ -5,7 +5,6 @@
 #
 from rest_framework import serializers
 from django.core.exceptions import FieldError
-from django.core.validators import RegexValidator
 
 from pdc.apps.common.fields import ChoiceSlugField
 from pdc.apps.common import models as common_models
@@ -34,8 +33,6 @@ class ProductVersionSerializer(StrictSerializerMixin, serializers.ModelSerialize
     releases = serializers.SerializerMethodField()
     product = serializers.SlugRelatedField(slug_field='short',
                                            queryset=Product.objects.all())
-    short = serializers.CharField(required=False, validators=[
-        RegexValidator(regex=r"^[a-z\-]+$", message='Only accept lowercase letter or -')])
 
     class Meta:
         model = ProductVersion
@@ -110,10 +107,11 @@ class ReleaseSerializer(StrictSerializerMixin, serializers.ModelSerializer):
 
 class BaseProductSerializer(StrictSerializerMixin, serializers.ModelSerializer):
     base_product_id = serializers.CharField(read_only=True)
+    release_type = ChoiceSlugField(slug_field='short', queryset=ReleaseType.objects.all())
 
     class Meta:
         model = BaseProduct
-        fields = ('base_product_id', 'short', 'version', 'name')
+        fields = ('base_product_id', 'short', 'version', 'name', 'release_type')
 
 
 class ReleaseTypeSerializer(StrictSerializerMixin, serializers.ModelSerializer):

--- a/pdc/apps/release/templates/base_product_detail.html
+++ b/pdc/apps/release/templates/base_product_detail.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block content %}
-<h2 class="page-header">{% trans 'Base Product' %} #{{ base_product.id }}: {{ base_product.short }}-{{ base_product.version }}</h2>
+<h2 class="page-header">{% trans 'Base Product' %} #{{ base_product.id }}: {{ base_product }}</h2>
 
 <dl class="details dl-horizontal">
     <dt>{% trans "ID" %}</dt>
@@ -13,6 +13,8 @@
     <dd>{{ base_product.short }}</dd>
     <dt>{% trans "Version" %}</dt>
     <dd>{{ base_product.version }}</dd>
+    <dt>{% trans "Type" %}</dt>
+    <dd>{{ base_product.release_type }}</dd>
 </dl>
 
 <h3 class="sub-header">{% trans 'Releases' %}</h3>

--- a/pdc/apps/release/templates/base_product_list_include.html
+++ b/pdc/apps/release/templates/base_product_list_include.html
@@ -6,6 +6,7 @@
     <th>{% trans "Name" %}</th>
     <th>{% trans "Short Name" %}</th>
     <th>{% trans "Version" %}</th>
+    <th>{% trans "Type" %}</th>
   </tr>
   </thead>
   <tbody>
@@ -15,6 +16,7 @@
     <td>{{ base_product.name }}</td>
     <td>{{ base_product.short }}</td>
     <td>{{ base_product.version }}</td>
+    <td>{{ base_product.release_type }}</td>
   </tr>
 {% endfor %}
   </tbody>

--- a/pdc/apps/release/templates/release_detail.html
+++ b/pdc/apps/release/templates/release_detail.html
@@ -34,7 +34,7 @@
     <dt>{% trans "Base Product" %}</dt>
     <dd>
       <a href="{% url "base_product/detail" release.base_product.id %}">
-        {{ release.base_product.name }} ({{ release.base_product.short }}-{{ release.base_product.version }})
+        {{ release.base_product.name }} ({{ release.base_product }})
       </a>
     </dd>
 {% endif %}


### PR DESCRIPTION
Added release_type to BaseProduct.
Validation of Release, ProductVersion, Product and BaseProduct fields is based on regexps from productmd.

Change release_ids to use '@' as separator between release and base product part.
Release_type can be in both parts of release_id now (for example foo-1.0-updates@fedora-23-updates).