### PR TITLE
Fixes to fedmsg message publication.

### DIFF
--- a/pdc/apps/utils/messaging.py
+++ b/pdc/apps/utils/messaging.py
@@ -36,7 +36,7 @@ class FedmsgMessenger(object):
         self.messenger = fedmsg
 
     def send_message(self, topic, msg):
-        self.messenger.publish(topic=topic, msg=msg)
+        self.messenger.publish(topic=topic.strip('.'), msg=msg)
 
 
 class ProtonMessenger(object):

--- a/pdc/apps/utils/messaging.py
+++ b/pdc/apps/utils/messaging.py
@@ -4,6 +4,7 @@
 # http://opensource.org/licenses/MIT
 #
 from django.conf import settings
+from django.utils import six
 
 import logging
 
@@ -36,7 +37,10 @@ class FedmsgMessenger(object):
         self.messenger = fedmsg
 
     def send_message(self, topic, msg):
-        self.messenger.publish(topic=topic.strip('.'), msg=msg)
+        topic = topic.strip('.')
+        if isinstance(msg, six.string_types):
+            msg = json.loads(msg)
+        self.messenger.publish(topic=topic, msg=msg)
 
 
 class ProtonMessenger(object):

--- a/pdc/apps/utils/messaging.py
+++ b/pdc/apps/utils/messaging.py
@@ -3,6 +3,8 @@
 # Licensed under The MIT License (MIT)
 # http://opensource.org/licenses/MIT
 #
+import json
+
 from django.conf import settings
 from django.utils import six
 


### PR DESCRIPTION
We hit this in production in Fedora just a few minutes ago.  The 'topic' here
in the PDC code was ``".compose"``.  Once that made it through the pipes it
came out the other side as ``'org.fedoraproject.prod.pdc..compose'`` (the
double dots in the middle are problematic).  This patch should take care of it
in the future.  (Although, perhaps you want to make the change somewhere else
more general that will help out the other messaging plugins as well?)

Furthermore, the ``msg`` was already encoded as JSON (which fedmsg then re-encoded).  So, we decode in the send_message method to avoid that.  (Example:  https://apps.fedoraproject.org/datagrepper/id?id=2016-83d610b3-da7a-4a44-b5f0-9edf75e795a4&is_raw=true&size=extra-large )