### PR TITLE
Write correct variant type in compose-tree-location_doc

### DIFF
--- a/pdc/apps/compose/serializers.py
+++ b/pdc/apps/compose/serializers.py
@@ -110,6 +110,7 @@ class OverrideRPMSerializer(StrictSerializerMixin, serializers.ModelSerializer):
 
 
 class ComposeTreeVariantField(serializers.Field):
+    doc_format = "Variant.variant_uid"
 
     def to_internal_value(self, data):
         request_data = self.context.get("request").data


### PR DESCRIPTION
In "create"  method  doc of compose-tree-location API, variant type is unknown; to show its type for user.

JIRA: PDC-1387