### PR TITLE
Compose-tree-locations be unique over scheme

### DIFF
--- a/pdc/apps/compose/migrations/0009_auto_20160321_0855.py
+++ b/pdc/apps/compose/migrations/0009_auto_20160321_0855.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('compose', '0008_composeimage_rtt_test_result'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='composetree',
+            unique_together=set([('compose', 'variant', 'arch', 'location', 'scheme')]),
+        ),
+    ]

--- a/pdc/apps/compose/models.py
+++ b/pdc/apps/compose/models.py
@@ -570,7 +570,7 @@ class ComposeTree(models.Model):
 
     class Meta:
         unique_together = (
-            ("compose", "variant", "arch", "location"),
+            ("compose", "variant", "arch", "location", "scheme"),
         )
 
     def __unicode__(self):

--- a/pdc/apps/compose/serializers.py
+++ b/pdc/apps/compose/serializers.py
@@ -145,7 +145,6 @@ class ComposeTreeSerializer(StrictSerializerMixin,
         compose = attrs.get('compose', None)
         variant = attrs.get('variant', None)
         arch = attrs.get('arch', None)
-
         if compose == variant.compose and arch in variant.arches:
             return attrs
         elif compose == variant.compose and arch not in variant.arches:

--- a/pdc/apps/compose/tests.py
+++ b/pdc/apps/compose/tests.py
@@ -2125,6 +2125,17 @@ class ComposeTreeAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertNumChanges([1])
 
+    def test_create_composetree_with_diff_scheme(self):
+        url = reverse('composetreelocations-list')
+        data = {'compose': 'compose-1', 'variant': 'Server', 'arch': 'x86_64', 'location': 'BRQ',
+                'url': 'nfs://nay.lab.la/', 'scheme': 'nfs', 'synced_content': ['debug']}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data = {'compose': 'compose-1', 'variant': 'Server', 'arch': 'x86_64', 'location': 'BRQ',
+                'url': 'nfs://nay.lab.la/', 'scheme': 'http', 'synced_content': ['debug']}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
     def test_create_composetree_without_compose(self):
         url = reverse('composetreelocations-list')
         data = {'variant': 'Server', 'arch': 'x86_64', 'location': 'BRQ',


### PR DESCRIPTION
When with same compose/variant/arch/location and diff scheme, it also can create a instance for Compose-tree-locations.

JIRA: PDC-1389