### PR TITLE
Visible for Arch names on compose page

### DIFF
--- a/pdc/apps/compose/templates/compose_detail.html
+++ b/pdc/apps/compose/templates/compose_detail.html
@@ -88,6 +88,10 @@
 }
 .compose-links.dl-horizontal dt {
     width: 4em;
+    overflow: visible;
+    text-align: left;
+    text-overflow: clip;
+    white-space: nowrap;
 }
 .compose-links.dl-horizontal dd {
     margin-left: 4.5em;


### PR DESCRIPTION
When the value of Arch with long string; it align left.

JIRA: PDC-1226