### PR TITLE
Visible for Arch names on compose page

### DIFF
--- a/pdc/apps/compose/templates/compose_detail.html
+++ b/pdc/apps/compose/templates/compose_detail.html
@@ -89,6 +89,7 @@
 .compose-links.dl-horizontal dt {
     width: 4em;
     overflow: visible;
+    text-align: right;
     text-overflow: clip;
     white-space: nowrap;
 }


### PR DESCRIPTION
When the value of Arch with a long string, align left.

JIRA: PDC-1226