### PR TITLE
Create Rpc/Overrides-rpm/clone.

### DIFF
--- a/pdc/apps/compose/fixtures/tests/more_release_mapping.json
+++ b/pdc/apps/compose/fixtures/tests/more_release_mapping.json
@@ -1,0 +1,70 @@
+[
+  {
+    "model": "release.Release",
+    "pk": 2,
+    "fields": {
+      "release_type": 1,
+      "release_id": "release-3.0",
+      "short": "release",
+      "name": "Test Release",
+      "version": "3.0",
+      "base_product": null,
+      "active": true
+    }
+  },
+  {
+    "model": "compose.Compose",
+    "pk": 2,
+    "fields": {
+      "release": 2,
+      "compose_id": "compose-2",
+      "compose_date": "2016-09-03",
+      "compose_type": 1,
+      "compose_respin": 1,
+      "compose_label": null,
+      "dt_imported": "2016-09-03T11:45:00+00:00",
+      "deleted": false,
+      "acceptance_testing": 1
+    }
+  },
+  {
+    "pk": 3,
+    "model": "compose.Variant",
+    "fields": {
+      "compose": 2,
+      "variant_id": "Server",
+      "variant_uid": "Server",
+      "variant_name": "Server",
+      "deleted": false,
+      "variant_type": 1
+    }
+  },
+  {
+    "model": "compose.ComposeTree",
+    "pk": 3,
+    "fields": {
+      "compose": 2,
+      "variant": 1,
+      "arch": 47,
+      "location": 2,
+      "scheme": 2,
+      "url": "nfs://nay.lab.la/",
+      "synced_content": [2]
+    }
+  },
+  {
+    "model": "compose.Scheme",
+    "pk": 2,
+    "fields": {
+      "name": "http"
+    }
+  },
+  {
+    "model": "compose.Location",
+    "pk": 2,
+    "fields": {
+      "name": "Beijing",
+      "short": "NAY"
+    }
+  }
+]

--- a/pdc/apps/compose/routers.py
+++ b/pdc/apps/compose/routers.py
@@ -19,6 +19,8 @@ router.register(r'compose-images', views.ComposeImageView)
 router.register('overrides/rpm',
                 views.ReleaseOverridesRPMViewSet,
                 base_name='overridesrpm')
+router.register(r'rpc/overrides-rpm/clone', views.OverridesRPMCloneViewSet,
+                base_name='overridesrpmclone')
 router.register(r'rpc/where-to-file-bugs', views.FilterBugzillaProductsAndComponents,
                 base_name='bugzilla')
 router.register('rpc/find-compose-by-release-rpm/(?P<release_id>[^/]+)/(?P<rpm_name>[^/]+)',

--- a/pdc/apps/compose/tests.py
+++ b/pdc/apps/compose/tests.py
@@ -753,6 +753,24 @@ class OverridesRPMCloneAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
                                      'target_release_id': target_release_id},
                                     format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertNumChanges([1, 1])
+
+    def test_clone_overridesRPM_with_orpm_existed_in_target_release(self):
+        args = {"name": "Supplementary", "short": "supp", "version": "1.1",
+                "release_type": "ga"}
+        target_response = self.client.post(reverse('release-list'), args)
+        self.assertEqual(target_response.status_code, status.HTTP_201_CREATED)
+        target_release_id = target_response.data['release_id']
+        response1 = self.client.post(reverse('overridesrpmclone-list'),
+                                     {'source_release_id': 'release-1.0',
+                                      'target_release_id': target_release_id},
+                                     format='json')
+        self.assertEqual(response1.status_code, status.HTTP_201_CREATED)
+        response = self.client.post(reverse('overridesrpmclone-list'),
+                                    {'source_release_id': 'release-1.0',
+                                     'target_release_id': target_release_id},
+                                    format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_clone__overridesRPM_with_filter_rpm_name(self):
         args = {"name": "Supplementary", "short": "supp", "version": "1.1",

--- a/pdc/apps/compose/views.py
+++ b/pdc/apps/compose/views.py
@@ -1347,14 +1347,13 @@ class OverridesRPMCloneViewSet(StrictQueryParamMixin, viewsets.GenericViewSet):
             return Response({'detail': '%s keys are not allowed' % list(extra_keys)},
                             status=status.HTTP_400_BAD_REQUEST)
 
-        if 'source_release_id' not in data:
-            return Response({'detail': 'Missing source_release_id'},
-                            status=status.HTTP_400_BAD_REQUEST)
+        for key in keys:
+            if key not in data:
+                return Response({'detail': 'Missing %s' % key},
+                                status=status.HTTP_400_BAD_REQUEST)
         source_release_id = data.pop('source_release_id')
-        if 'target_release_id' not in data:
-            return Response({'detail': 'Missing target_release_id'},
-                            status=status.HTTP_400_BAD_REQUEST)
         target_release_id = data.pop('target_release_id')
+
         try:
             source_release = get_object_or_404(Release, release_id=source_release_id)
         except Http404:
@@ -1390,13 +1389,11 @@ class OverridesRPMCloneViewSet(StrictQueryParamMixin, viewsets.GenericViewSet):
                 results.append(orpm.export())
                 request.changeset.add('OverridesRPM', orpm.pk,
                                       'null', json.dumps(orpm.export()))
-            else:
-                continue
         if results:
             return Response(status=status.HTTP_201_CREATED, data=results)
         else:
-            return Response({'detail': 'Both releases contain the same overrides-rpm'},
-                            status=status.HTTP_400_BAD_REQUEST)
+            return Response({'detail': 'overridesRPMs have existed in target release'},
+                            status=status.HTTP_200_OK)
 
 
 class FilterBugzillaProductsAndComponents(StrictQueryParamMixin,


### PR DESCRIPTION
Clone overrides-rpm from one release to annother.

Each optional argument specifies which type of overrides get copied.
If multiple are specified all have to match for override to be copied.

Both releases have to exist.

If target_release already has overrides, they do not get removed.

JIRA: PDC-1343