### PR TITLE
Dsable eus/aus repo checks

### DIFF
--- a/pdc/apps/repository/models.py
+++ b/pdc/apps/repository/models.py
@@ -6,7 +6,6 @@
 #
 
 
-from django.core.exceptions import ValidationError
 from django.db import models
 
 from pdc.apps.common.models import get_cached_id
@@ -92,39 +91,6 @@ class Repo(models.Model):
 
     def __unicode__(self):
         return u"%s" % self.name
-
-    def clean(self):
-        content_category = self.content_category.name
-        if content_category == "debug" and "debug" not in self.name:
-            raise ValidationError("Missing 'debug' in repo name '%s'" % self.name)
-        if content_category != "debug" and "debug" in self.name:
-            raise ValidationError("Found 'debug' in repo name '%s', but content category is '%s'"
-                                  % (self.name, content_category))
-
-        release_type = self.variant_arch.variant.release.release_type.short
-        if release_type == "fast" and "-fast" not in self.name:
-            raise ValidationError("Missing '-fast' in repo name '%s'" % self.name)
-        if release_type != "fast" and "-fast" in self.name:
-            raise ValidationError("Found '-fast' in repo name '%s', but release type is '%s'"
-                                  % (self.name, release_type))
-
-        if release_type == "eus" and ".z" not in self.name:
-            raise ValidationError("Missing '.z' in repo name '%s'" % self.name)
-        if release_type != "eus" and ".z" in self.name:
-            raise ValidationError("Found '.z' in repo name '%s', but release type is '%s'"
-                                  % (self.name, release_type))
-
-        if release_type == "aus" and (".aus" not in self.name and ".ll" not in self.name):
-            raise ValidationError("Missing '.aus' or '.ll' in repo name '%s'" % self.name)
-        if release_type != "aus" and (".aus" in self.name or ".ll" in self.name):
-            raise ValidationError("Found '.aus' or '.ll' in repo name '%s', but release type is '%s'"
-                                  % (self.name, release_type))
-
-        if release_type == "els" and "els" not in self.name:
-            raise ValidationError("Missing 'els' in repo name '%s'" % self.name)
-        if release_type != "els" and "els" in self.name:
-            raise ValidationError("Found 'els' in repo name '%s', but release type is '%s'"
-                                  % (self.name, release_type))
 
     def export(self):
         return {

--- a/pdc/apps/repository/tests.py
+++ b/pdc/apps/repository/tests.py
@@ -53,13 +53,6 @@ class RepositorySerializerTestCase(APITestCase):
         obj = serializer.save()
         self.assertFalse(obj.shadow)
 
-    def test_deserialize_invalid_from_custom_validator(self):
-        self.data['content_category'] = 'debug'
-        serializer = serializers.RepoSerializer(data=self.data)
-        self.assertFalse(serializer.is_valid())
-        self.assertEqual(serializer.errors,
-                         {'detail': ["Missing 'debug' in repo name 'test_repo_2'"]})
-
     def test_deserialize_invalid_shadow(self):
         self.data['shadow'] = 'very shadow'
         serializer = serializers.RepoSerializer(data=self.data)
@@ -193,13 +186,6 @@ class RepositoryRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.existing['variant_uid'] = 'Client'
         self.assertDictEqual(dict(response.data), self.existing)
         self.assertNumChanges([1])
-
-    def test_update_partial_bad_name(self):
-        response = self.client.patch(reverse('contentdeliveryrepos-detail', args=[1]),
-                                     {'name': 'repo-debug-isos'},
-                                     format='json')
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertNumChanges([])
 
     def test_update_partial_bad_variant(self):
         response = self.client.patch(reverse('contentdeliveryrepos-detail', args=[1]),


### PR DESCRIPTION
When converting data from ET to PDC, the restrictions on repo names (which are there for a good reason) don't meet with historical data:
* Updates releases can contain EUS and AUS repos
* EUS releases can contain AUS repos

The checks to be modified or disabled in order to be able to import the data.

JIRA: PDC-1426