### PR TITLE
Store relative paths to variant/$arch/$content_category_name dir

### DIFF
--- a/pdc/apps/compose/migrations/0010_auto_20160407_1322.py
+++ b/pdc/apps/compose/migrations/0010_auto_20160407_1322.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('common', '0002_auto_20150512_0703'),
+        ('compose', '0009_auto_20160321_0855'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ComposeRelPath',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('path', models.CharField(max_length=2000)),
+                ('arch', models.ForeignKey(to='common.Arch')),
+                ('compose', models.ForeignKey(to='compose.Compose')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='PathType',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=255)),
+            ],
+        ),
+        migrations.AddField(
+            model_name='composerelpath',
+            name='type',
+            field=models.ForeignKey(to='compose.PathType'),
+        ),
+        migrations.AddField(
+            model_name='composerelpath',
+            name='variant',
+            field=models.ForeignKey(to='compose.Variant'),
+        ),
+    ]

--- a/pdc/apps/compose/models.py
+++ b/pdc/apps/compose/models.py
@@ -586,3 +586,35 @@ class ComposeTree(models.Model):
             "url": self.url,
             "synced_content": [item.name for item in self.synced_content.all()]
         }
+
+
+class PathType(models.Model):
+    name = models.CharField(max_length=255)
+
+    def __unicode__(self):
+        return self.name
+
+    def export(self):
+        return {
+            "name": self.name,
+        }
+
+
+class ComposeRelPath(models.Model):
+    path                = models.CharField(max_length=2000)
+    compose             = models.ForeignKey("Compose")
+    variant             = models.ForeignKey("Variant")
+    arch                = models.ForeignKey("common.Arch")
+    type                = models.ForeignKey("PathType")
+
+    def __unicode__(self):
+        return u"%s-%s-%s-%s-%s" % (self.compose, self.variant, self.arch, self.type.name, self.path)
+
+    def export(self):
+        return {
+            "compose": self.compose.compose_id,
+            "variant": self.variant.variant_uid,
+            "arch": self.arch.name,
+            "type": self.type.name,
+            "path": self.path
+        }

--- a/pdc/apps/compose/tests.py
+++ b/pdc/apps/compose/tests.py
@@ -902,6 +902,7 @@ class ComposeRPMViewAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_import_and_retrieve_manifest(self):
+        self.assertEqual(models.ComposeRelPath.objects.count(), 0)
         response = self.client.post(reverse('composerpm-list'),
                                     {'rpm_manifest': self.manifest,
                                      'release_id': 'tp-1.0',
@@ -910,8 +911,9 @@ class ComposeRPMViewAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data.get('compose'), 'TP-1.0-20150310.0')
         self.assertEqual(response.data.get('imported rpms'), 6)
-        self.assertNumChanges([11, 5])
+        self.assertNumChanges([11, 70])
         self.assertEqual(models.ComposeRPM.objects.count(), 6)
+        self.assertGreater(models.ComposeRelPath.objects.count(), 0)
         response = self.client.get(reverse('composerpm-detail', args=['TP-1.0-20150310.0']))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(dict(response.data),
@@ -948,6 +950,7 @@ class ComposeImageAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
         models.Path.CACHE = {}
 
     def test_import_images(self):
+        self.assertEqual(models.ComposeRelPath.objects.count(), 0)
         response = self.client.post(reverse('composeimage-list'),
                                     {'image_manifest': self.manifest,
                                      'release_id': 'tp-1.0',
@@ -956,11 +959,12 @@ class ComposeImageAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data.get('compose'), 'TP-1.0-20150310.0')
         self.assertEqual(response.data.get('imported images'), 4)
-        self.assertNumChanges([11, 5])
+        self.assertNumChanges([11, 70])
         self.assertEqual(models.ComposeImage.objects.count(), 4)
         response = self.client.get(reverse('image-list'), {'compose': 'TP-1.0-20150310.0'})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('count'), 4)
+        self.assertGreater(models.ComposeRelPath.objects.count(), 0)
 
         response = self.client.post(reverse('composeimage-list'),
                                     {'image_manifest': self.manifest,
@@ -1033,7 +1037,7 @@ class ComposeFullImportViewAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.data.get('compose'), 'TP-1.0-20150310.0')
         self.assertEqual(response.data.get('imported rpms'), 6)
         self.assertEqual(response.data.get('imported images'), 4)
-        self.assertNumChanges([11, 7])
+        self.assertNumChanges([11, 72])
         self.assertEqual(models.ComposeRPM.objects.count(), 6)
         self.assertEqual(models.ComposeImage.objects.count(), 4)
 


### PR DESCRIPTION
Stare relative paths when importing compose images and compose
rpms. The path is stored with compose, variant, arch, path type.

JIRA: PDC-1358