### PR TITLE
rebrand

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ FROM fedora:21
 MAINTAINER Zhikun Lao <zlao@redhat.com>
 
 LABEL Description = "product-definition-center"
-LABEL Vendor = "Red Hat"
+LABEL Vendor = "Fedora"
 LABEL Version = "0.5"
 
 # patternfly1


### PR DESCRIPTION
This is mainly so that the home page doesn't single out Red Hat.

"...which are required to support automation of {Red Hat -> Fedora}
engineering workflows..."