### PR TITLE
rebrand

### DIFF
--- a/pdc/templates/home/index.html
+++ b/pdc/templates/home/index.html
@@ -10,11 +10,10 @@
 
 The Product Definition Center is repository and API for storing and
 querying metadata related to packages, product releases, engineering
-processes and artifacts which are required to support automation of Red
-Hat engineering workflows (or productization processes). It aims to
-support the development of automation that ties in the different tools
-to streamline productization processes and create more efficient
-workflows.
+processes and artifacts which are required to support automation of release
+engineering workflows (or productization processes). It aims to support the
+development of automation that ties in the different tools to streamline
+productization processes and create more efficient workflows.
 <br />
 You will most likely want to have a look at our <a href="{% url 'api-root' %}">{% trans 'API documentation' %}</a>:
 <br />


### PR DESCRIPTION
This is mainly so that the home page doesn't single out Red Hat.

"...which are required to support automation of {Red Hat -> Fedora}
engineering workflows..."

This time editing the correct document (hopefully).
