### PR TITLE
Get compose path based on just compose_id/location/schema

### DIFF
--- a/pdc/apps/compose/routers.py
+++ b/pdc/apps/compose/routers.py
@@ -37,5 +37,8 @@ router.register('rpc/compose-full-import',
                 base_name='composefullimport')
 router.register(r'compose-tree-locations', views.ComposeTreeViewSet,
                 base_name='composetreelocations')
+router.register(r'compose-locations/(?P<compose_id>[^/]+)/(?P<location_id>[^/]+)/(?P<schema>[^/]+)',
+                views.ComposeLocationViewSet,
+                base_name='composelocations')
 router.register(r'compose-image-rtt-tests', views.ComposeImageRTTTestViewSet,
                 base_name='composeimagertttests')


### PR DESCRIPTION
Add a new end point: compose-locations/(?P<compose_id>[^/]+)/
(?P<location_id>[^/]+)/(?P<schema>[^/]+) to get compose location
according to compose tree location's url.
If the url data is inconsistent, one of them will be returned
as result and pdc-warning will be returned in HTTP header.

JIRA: PDC-1346