### PR TITLE
Enable query with multi values.

### DIFF
--- a/pdc/apps/common/tests.py
+++ b/pdc/apps/common/tests.py
@@ -332,6 +332,11 @@ class SigKeyRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.data['count'], 1)
         self.assertEqual(response.data['results'][0]['key_id'], 'd343aaaa')
 
+    def test_query_multi_value(self):
+        response = self.client.get(reverse('sigkey-list') + '?key_id=1234adbf&key_id=f2134bca')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 2)
+
     def test_retrieve_sigkey(self):
         url = reverse('sigkey-detail', kwargs={'key_id': '1234adbf'})
         response = self.client.get(url, format='json')

--- a/pdc/apps/compose/filters.py
+++ b/pdc/apps/compose/filters.py
@@ -9,33 +9,32 @@ import django_filters
 from django.db.models import Q
 from django.core.exceptions import ValidationError
 
-from pdc.apps.common.filters import value_is_not_empty, MultiValueFilter, CaseInsensitiveBooleanFilter
+from pdc.apps.common.filters import value_is_not_empty, MultiValueFilter, CaseInsensitiveBooleanFilter, \
+    MultiValueCaseInsensitiveFilter
 from .models import Compose, OverrideRPM, ComposeTree, ComposeImage
 
 
 class ComposeFilter(django_filters.FilterSet):
-    release             = django_filters.CharFilter(name='release__release_id', lookup_type='iexact')
-    compose_id          = django_filters.CharFilter(name='compose_id', lookup_type='iexact')
-    compose_type        = django_filters.CharFilter(name='compose_type__name', lookup_type='iexact')
-    acceptance_testing  = django_filters.CharFilter(name='acceptance_testing__name')
-    srpm_name           = django_filters.CharFilter(name='variant__variantarch__composerpm__rpm__srpm_name',
-                                                    lookup_type='iexact',
-                                                    distinct=True)
-    rpm_name            = django_filters.CharFilter(name='variant__variantarch__composerpm__rpm__name',
-                                                    lookup_type='iexact',
-                                                    distinct=True)
-    rpm_version         = django_filters.CharFilter(name='variant__variantarch__composerpm__rpm__version',
-                                                    lookup_type='iexact',
-                                                    distinct=True)
-    rpm_release         = django_filters.CharFilter(name='variant__variantarch__composerpm__rpm__release',
-                                                    lookup_type='iexact',
-                                                    distinct=True)
-    rpm_arch            = django_filters.CharFilter(name='variant__variantarch__composerpm__rpm__arch',
-                                                    lookup_type='iexact',
-                                                    distinct=True)
+    release             = MultiValueCaseInsensitiveFilter(name='release__release_id')
+    compose_id          = MultiValueCaseInsensitiveFilter(name='compose_id')
+    compose_type        = MultiValueCaseInsensitiveFilter(name='compose_type__name')
+    acceptance_testing  = MultiValueFilter(name='acceptance_testing__name')
+    srpm_name           = MultiValueCaseInsensitiveFilter(name='variant__variantarch__composerpm__rpm__srpm_name',
+                                                          distinct=True)
+    rpm_name            = MultiValueCaseInsensitiveFilter(name='variant__variantarch__composerpm__rpm__name',
+                                                          distinct=True)
+    rpm_version         = MultiValueCaseInsensitiveFilter(name='variant__variantarch__composerpm__rpm__version',
+                                                          distinct=True)
+    rpm_release         = MultiValueCaseInsensitiveFilter(name='variant__variantarch__composerpm__rpm__release',
+                                                          distinct=True)
+    rpm_arch            = MultiValueCaseInsensitiveFilter(name='variant__variantarch__composerpm__rpm__arch',
+                                                          distinct=True)
     rpm_nvr             = django_filters.MethodFilter(action="filter_nvr")
     rpm_nvra            = django_filters.MethodFilter(action="filter_nvra")
     deleted             = CaseInsensitiveBooleanFilter()
+    compose_date        = MultiValueFilter(name='compose_date')
+    compose_respin      = MultiValueFilter(name='compose_respin')
+    compose_label       = MultiValueFilter(name='compose_label')
     # TODO: return only latest compose
 
     @value_is_not_empty
@@ -72,8 +71,13 @@ class ComposeFilter(django_filters.FilterSet):
 
 
 class OverrideRPMFilter(django_filters.FilterSet):
-    release = django_filters.CharFilter(name='release__release_id', lookup_type='iexact')
-    comment = django_filters.CharFilter(lookup_type='icontains')
+    release     = MultiValueCaseInsensitiveFilter(name='release__release_id')
+    comment     = django_filters.CharFilter(lookup_type='icontains')
+    arch        = MultiValueFilter(name='arch')
+    variant     = MultiValueFilter(name='variant')
+    srpm_name   = MultiValueFilter(name='srpm_name')
+    rpm_name    = MultiValueFilter(name='rpm_name')
+    rpm_arch    = MultiValueFilter(name='rpm_arch')
 
     class Meta:
         model = OverrideRPM
@@ -81,11 +85,11 @@ class OverrideRPMFilter(django_filters.FilterSet):
 
 
 class ComposeTreeFilter(django_filters.FilterSet):
-    compose         = django_filters.CharFilter(name='compose__compose_id', lookup_type='iexact')
-    variant         = django_filters.CharFilter(name='variant__variant_uid', lookup_type='iexact')
-    arch            = django_filters.CharFilter(name='arch__name', lookup_type='iexact')
-    location        = django_filters.CharFilter(name='location__short', lookup_type='iexact')
-    scheme          = django_filters.CharFilter(name='scheme__name', lookup_type='iexact')
+    compose         = MultiValueCaseInsensitiveFilter(name='compose__compose_id')
+    variant         = MultiValueCaseInsensitiveFilter(name='variant__variant_uid')
+    arch            = MultiValueCaseInsensitiveFilter(name='arch__name')
+    location        = MultiValueCaseInsensitiveFilter(name='location__short')
+    scheme          = MultiValueCaseInsensitiveFilter(name='scheme__name')
 
     class Meta:
         model = ComposeTree

--- a/pdc/apps/compose/fixtures/tests/more_composes.json
+++ b/pdc/apps/compose/fixtures/tests/more_composes.json
@@ -8,7 +8,7 @@
       "compose_date": "2014-09-08",
       "compose_type": 1,
       "compose_respin": 1,
-      "compose_label": null,
+      "compose_label": "compose-2 label",
       "dt_imported": "2014-09-03T11:45:00+00:00",
       "deleted": false,
       "acceptance_testing": 1
@@ -41,8 +41,8 @@
       "compose_id": "compose-3",
       "compose_date": "2014-09-09",
       "compose_type": 2,
-      "compose_respin": 1,
-      "compose_label": null,
+      "compose_respin": 2,
+      "compose_label": "compose-3 label",
       "dt_imported": "2014-09-03T11:45:00+00:00",
       "deleted": false,
       "acceptance_testing": 1
@@ -107,14 +107,14 @@
     "model": "package.RPM",
     "pk": 3,
     "fields": {
-      "name": "bash",
+      "name": "bash1",
       "epoch": 0,
       "version": "1.2.3",
       "release": "4.b1",
       "arch": "src",
-      "srpm_name": "bash",
+      "srpm_name": "bash1",
       "srpm_nevra": null,
-      "filename": "bash-1.2.3-4.b1.src.rpm"
+      "filename": "bash1-1.2.3-4.b1.src.rpm"
     }
   },
   {

--- a/pdc/apps/release/filters.py
+++ b/pdc/apps/release/filters.py
@@ -6,7 +6,7 @@
 import django_filters
 
 from pdc.apps.common import filters
-from .models import Release, ProductVersion, Product, ReleaseType, Variant
+from .models import Release, ProductVersion, Product, ReleaseType, Variant, BaseProduct
 
 
 class ActiveReleasesFilter(filters.CaseInsensitiveBooleanFilter):
@@ -29,12 +29,16 @@ class ActiveReleasesFilter(filters.CaseInsensitiveBooleanFilter):
 
 
 class ReleaseFilter(django_filters.FilterSet):
-    base_product = django_filters.CharFilter(name='base_product__base_product_id')
+    release_id = filters.MultiValueFilter(name='release_id')
+    base_product = filters.MultiValueFilter(name='base_product__base_product_id')
     has_base_product = django_filters.MethodFilter(action='find_has_base_product')
-    release_type = django_filters.CharFilter(name='release_type__short')
-    product_version = django_filters.CharFilter(name='product_version__product_version_id')
+    release_type = filters.MultiValueFilter(name='release_type__short')
+    product_version = filters.MultiValueFilter(name='product_version__product_version_id')
     integrated_with = filters.NullableCharFilter(name='integrated_with__release_id')
     active = filters.CaseInsensitiveBooleanFilter()
+    name = filters.MultiValueFilter(name='name')
+    short = filters.MultiValueFilter(name='short')
+    version = filters.MultiValueFilter(name='version')
 
     class Meta:
         model = Release
@@ -52,8 +56,23 @@ class ReleaseFilter(django_filters.FilterSet):
         return queryset
 
 
+class BaseProductFilter(django_filters.FilterSet):
+    short               = filters.MultiValueFilter(name='short')
+    version             = filters.MultiValueFilter(name='version')
+    name                = filters.MultiValueFilter(name='name')
+    base_product_id     = filters.MultiValueFilter(name='base_product_id')
+
+    class Meta:
+        model = BaseProduct
+        fields = ("base_product_id", "short", "version", 'name')
+
+
 class ProductVersionFilter(django_filters.FilterSet):
-    active = ActiveReleasesFilter(name='release')
+    active              = ActiveReleasesFilter(name='release')
+    short               = filters.MultiValueFilter(name='short')
+    version             = filters.MultiValueFilter(name='version')
+    name                = filters.MultiValueFilter(name='name')
+    product_version_id  = filters.MultiValueFilter(name='product_version_id')
 
     class Meta:
         model = ProductVersion
@@ -62,6 +81,8 @@ class ProductVersionFilter(django_filters.FilterSet):
 
 class ProductFilter(django_filters.FilterSet):
     active = ActiveReleasesFilter(name='productversion__release')
+    name = filters.MultiValueFilter(name='name')
+    short = filters.MultiValueFilter(name='short')
 
     class Meta:
         model = Product
@@ -70,7 +91,7 @@ class ProductFilter(django_filters.FilterSet):
 
 class ReleaseTypeFilter(django_filters.FilterSet):
     name = django_filters.CharFilter(lookup_type="icontains")
-    short = django_filters.CharFilter()
+    short = filters.MultiValueFilter(name='short')
 
     class Meta:
         model = ReleaseType

--- a/pdc/apps/release/views.py
+++ b/pdc/apps/release/views.py
@@ -478,7 +478,7 @@ class BaseProductViewSet(ChangeSetCreateModelMixin,
     serializer_class = BaseProductSerializer
     lookup_field = 'base_product_id'
     lookup_value_regex = '[^/]+'
-    filter_fields = ('base_product_id', 'name', 'short', 'version')
+    filter_class = filters.BaseProductFilter
 
     def create(self, *args, **kwargs):
         """

--- a/pdc/apps/repository/filters.py
+++ b/pdc/apps/repository/filters.py
@@ -19,6 +19,7 @@ class RepoFilter(filters.FilterSet):
     service = MultiValueFilter(name='service__name')
     shadow = CaseInsensitiveBooleanFilter()
     product_id = MultiIntFilter()
+    name = MultiValueFilter(name='name')
 
     class Meta:
         model = models.Repo

--- a/pdc/apps/repository/tests.py
+++ b/pdc/apps/repository/tests.py
@@ -333,6 +333,11 @@ class RepositoryMultipleFilterTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 2 * 27)
 
+    def test_multiple_names(self):
+        response = self.client.get(reverse('contentdeliveryrepos-list') + '?name=repo-pulp-beta-rpm-debug&name=repo-ftp-htb-iso-source')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 2)
+
     def test_multiple_combination(self):
         query = ('?service=pulp&service=ftp' +
                  '&repo_family=beta&repo_family=htb' +
@@ -341,6 +346,23 @@ class RepositoryMultipleFilterTestCase(APITestCase):
         response = self.client.get(reverse('contentdeliveryrepos-list') + query)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 16)
+
+    def test_multiple_product_id(self):
+        response = self.client.patch(reverse('contentdeliveryrepos-detail', args=[1]),
+                                     {'product_id': 32},
+                                     format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['product_id'], 32)
+
+        response = self.client.patch(reverse('contentdeliveryrepos-detail', args=[2]),
+                                     {'product_id': 31},
+                                     format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['product_id'], 31)
+
+        response = self.client.get(reverse('contentdeliveryrepos-list') + '?product_id=32&product_id=31')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 2)
 
 
 class RepositoryCloneTestCase(TestCaseWithChangeSetMixin, APITestCase):


### PR DESCRIPTION
It doesn't make sense to enable multi value for following param.
1. Boolean param.
2. Param with substring match.
3. Param with few kinds of type.

NullableCharFilter and MethodFilter with special filter logic
are not enabled as well.

JIRA: PDC-1459