### PR TITLE
Get rpm-mapping when release has no compose.

### DIFF
--- a/pdc/apps/compose/models.py
+++ b/pdc/apps/compose/models.py
@@ -139,7 +139,7 @@ class Compose(models.Model):
         if not disable_overrides:
             useless_overrides = mapping.apply_overrides(overrides)
 
-        return (mapping, useless_overrides)
+        return mapping, useless_overrides
 
     def get_rpms(self, rpm_name):
         """
@@ -325,6 +325,13 @@ class ComposeRPMMapping(object):
             useless_overrides.append(override)
         else:
             to_be_deleted.append(override)
+
+    def get_rpm_mapping_only_with_overrides(self, package, disable_overrides, release):
+        useless_overrides = []
+        overrides = OverrideRPM.objects.filter(release=release).filter(srpm_name=package)
+        if not disable_overrides:
+            useless_overrides = self.apply_overrides(overrides)
+        return self, useless_overrides
 
     def apply_overrides(self, overrides, do_delete=True):
         tbd = []

--- a/pdc/apps/release/tests.py
+++ b/pdc/apps/release/tests.py
@@ -976,6 +976,23 @@ class ReleaseRPMMappingViewSetTestCase(APITestCase):
                                    args=['product-1.0', 'bash']))
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_get_for_no_compose_without_include(self):
+        compose_models.Compose.objects.filter(release__release_id='release-1.0').delete()
+        response = self.client.get(reverse('releaserpmmapping-detail',
+                                   args=['release-1.0', 'bash']))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_for_no_compose_with_include(self):
+        override = compose_models.OverrideRPM.objects.get(id=1)
+        override.include = True
+        override.save()
+
+        compose_models.Compose.objects.filter(release__release_id='release-1.0').delete()
+        response = self.client.get(reverse('releaserpmmapping-detail',
+                                   args=['release-1.0', 'bash']))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"compose": None, "mapping": {"Server": {"x86_64": {"bash-doc": ["x86_64"]}}}})
+
     def test_get_for_nonexisting_release(self):
         response = self.client.get(reverse('releaserpmmapping-detail',
                                    args=['product-1.1', 'bash']))


### PR DESCRIPTION
For releases/{release_id}/rpm-mapping API, when
release has no compose. Set compose rpm mapping
part as empty dict and perform other steps.

JIRA: PDC-1461