### PR TITLE
Handle release has no compose in web UI

### DIFF
--- a/pdc/apps/compose/templates/overrides_form.html
+++ b/pdc/apps/compose/templates/overrides_form.html
@@ -10,7 +10,9 @@
     {% include "help_button.html" %}
 </h1>
 
-<p>Based on <strong>{{ compose.compose_id }}</strong></p>
+{% if compose %}
+    <p>Based on <strong>{{ compose.compose_id }}</strong></p>
+{% endif %}
 
 {% if has_errors %}
 <div class="alert alert-danger" role="alert">

--- a/pdc/apps/compose/views.py
+++ b/pdc/apps/compose/views.py
@@ -169,8 +169,10 @@ class RPMOverrideFormView(View):
         if self.compose:
             mapping, useless = self.compose.get_rpm_mapping(self.request.GET['package'], release=release)
         else:
-            mapping = {}
-            useless = []
+            mapping = ComposeRPMMapping()
+            mapping, useless = mapping.get_rpm_mapping_only_with_overrides(self.request.GET['package'], False,
+                                                                           release=release)
+
         checkboxes = []
         overs = set()
         for variant, arch, rpm_name, rpm_data in mapping:


### PR DESCRIPTION
Handle relase has no compose in 'Manage Overrides' detail page.
'Based on' string is removed and overrides are displayed.

JIRA: PDC-1466