### PR TITLE
Add two new rules to API stability

### DIFF
--- a/docs/source/using_api.rst
+++ b/docs/source/using_api.rst
@@ -23,6 +23,11 @@ In this context, stable means:
  * Arguments for APIs will not be removed or renamed
  * Keys in returned JSON dictionaries will not be removed or renamed
  * If new features are added to these APIs – which is quite possible – they will not break or change the meaning of existing methods. In other words, “stable” does not (necessarily) mean *complete*
+ * Default values of optional arguments will not change
+ * Order of returned results will not change for following results:
+    * releases in releases resource API
+    * composes inside compose_set in releases resource API
+    * composes in composes resource API
  * If, for some reason, an API declared stable must be removed or replaced, it will be declared deprecated in given version of the API and removed/replaced in future version of API
  * We’ll only break backwards compatibility of these APIs if a bug or security hole makes it completely unavoidable.
 


### PR DESCRIPTION
- default values of optional arguments

  If default value of optional argument changes, existing API users could
  suddenly supply incomplete/incorrect information for their use case

- order of returned results

  If order of multiple results changes it can affect how it's interpreted by the
  clients. For example releases returned for given product ID, or composes for
  given release ID.

Change-Id: Icfc10ce5db2d90fae56e0debbcc2476a11494471