### PR TITLE
Allow using mod_auth_oidc for remote user auth.

### DIFF
--- a/pdc/settings.py
+++ b/pdc/settings.py
@@ -129,6 +129,7 @@ if 'test' in sys.argv:
 AUTHENTICATION_BACKENDS = (
     'pdc.apps.auth.backends.KerberosUserBackend',
     #'pdc.apps.auth.backends.AuthMellonUserBackend',
+    #'pdc.apps.auth.backends.AuthOIDCUserBackend',
     'django.contrib.auth.backends.ModelBackend',
 )
 


### PR DESCRIPTION
We'd like to try this out in Fedora.
