### PR TITLE
Change the way to generate resource permissions automatically.

### DIFF
--- a/pdc/settings.py
+++ b/pdc/settings.py
@@ -118,12 +118,10 @@ MIDDLEWARE_CLASSES = [
     'pdc.apps.usage.middleware.UsageMiddleware',
     'pdc.apps.changeset.middleware.ChangesetMiddleware',
     'pdc.apps.utils.middleware.MessagingMiddleware',
-    'pdc.apps.utils.middleware.ResourceCollectingMiddleware',
     'pdc.apps.utils.middleware.RestrictAdminMiddleware'
 ]
 
 if 'test' in sys.argv:
-    MIDDLEWARE_CLASSES.remove('pdc.apps.utils.middleware.ResourceCollectingMiddleware')
     MIDDLEWARE_CLASSES.remove('pdc.apps.utils.middleware.RestrictAdminMiddleware')
 
 AUTHENTICATION_BACKENDS = (


### PR DESCRIPTION
Now when a special parameter 'create' set to true in
resource permissions list method. It will generate
resource permissions.
The old middleware way looks not work well in production
environment.

JIRA: PDC-1380