### PR TITLE
Put permission control on more resources and show correct permissions.

### DIFF
--- a/pdc/apps/auth/permissions.py
+++ b/pdc/apps/auth/permissions.py
@@ -4,6 +4,7 @@ from restfw_composed_permissions.generic.components import AllowAll
 from django.conf import settings
 
 from pdc.apps.auth.models import Resource, GroupResourcePermission
+from pdc.apps.utils.utils import read_permission_for_all
 
 
 class APIPermissionComponent(BasePermissionComponent):
@@ -17,8 +18,7 @@ class APIPermissionComponent(BasePermissionComponent):
             return True
         api_name = request.path.replace("%s%s/" % (settings.REST_API_URL, settings.REST_API_VERSION), '').strip('/')
         internal_permission = self._convert_permission(request.method)
-        if not internal_permission or (hasattr(settings, 'ALLOW_ALL_USER_READ') and
-                                       settings.ALLOW_ALL_USER_READ and internal_permission == 'read'):
+        if not internal_permission or (read_permission_for_all() and internal_permission == 'read'):
             return True
         return self._has_permission(internal_permission, request.user, str(view.__class__), api_name)
 

--- a/pdc/apps/changeset/views.py
+++ b/pdc/apps/changeset/views.py
@@ -10,6 +10,7 @@ from django.views.generic import ListView, DetailView
 from rest_framework import viewsets, status
 from rest_framework.response import Response
 
+from pdc.apps.auth.permissions import APIPermission
 from pdc.apps.common.viewsets import StrictQueryParamMixin
 from . import models
 from .filters import ChangesetFilterSet
@@ -189,3 +190,4 @@ class ChangesetViewSet(StrictQueryParamMixin,
     serializer_class = ChangesetSerializer
     queryset = models.Changeset.objects.all().order_by('-committed_on')
     filter_class = ChangesetFilterSet
+    permission_classes = (APIPermission,)

--- a/pdc/apps/common/views.py
+++ b/pdc/apps/common/views.py
@@ -9,6 +9,7 @@ from django.shortcuts import render
 from django.views import defaults
 from django.http import HttpResponse
 
+from pdc.apps.auth.permissions import APIPermission
 from pdc.apps.common.constants import PUT_OPTIONAL_PARAM_WARNING
 
 from rest_framework import viewsets, mixins, status
@@ -211,6 +212,7 @@ class ArchViewSet(pdc_viewsets.ChangeSetCreateModelMixin,
     serializer_class = ArchSerializer
     queryset = Arch.objects.all().order_by('id')
     lookup_field = 'name'
+    permission_classes = (APIPermission,)
 
     def list(self, request, *args, **kwargs):
         """
@@ -295,6 +297,7 @@ class SigKeyViewSet(pdc_viewsets.StrictQueryParamMixin,
     filter_class = SigKeyFilter
     lookup_field = 'key_id'
     docstring_macros = PUT_OPTIONAL_PARAM_WARNING
+    permission_classes = (APIPermission,)
 
     def list(self, request, *args, **kwargs):
         """

--- a/pdc/apps/compose/views.py
+++ b/pdc/apps/compose/views.py
@@ -1408,6 +1408,7 @@ class FilterBugzillaProductsAndComponents(StrictQueryParamMixin,
     """
     queryset = ComposeRPM.objects.none()    # Required for permissions
     extra_query_params = ('nvr', )
+    permission_classes = (APIPermission,)
 
     def list(self, request):
         """
@@ -1734,6 +1735,7 @@ class ComposeImageRTTTestViewSet(ChangeSetUpdateModelMixin,
     queryset = ComposeImage.objects.select_related('variant_arch', 'image').all()
     serializer_class = ComposeImageRTTTestSerializer
     filter_class = ComposeImageRTTTestFilter
+    permission_classes = (APIPermission,)
 
     lookup_fields = (
         ('variant_arch__variant__compose__compose_id', r'[^/]+'),

--- a/pdc/apps/package/views.py
+++ b/pdc/apps/package/views.py
@@ -139,6 +139,7 @@ class ImageViewSet(pdc_viewsets.StrictQueryParamMixin,
     queryset = models.Image.objects.all().order_by('id')
     serializer_class = serializers.ImageSerializer
     filter_class = filters.ImageFilter
+    permission_classes = (APIPermission,)
 
     def list(self, request):
         """

--- a/pdc/apps/release/views.py
+++ b/pdc/apps/release/views.py
@@ -814,6 +814,7 @@ class ReleaseTypeViewSet(StrictQueryParamMixin,
     queryset = models.ReleaseType.objects.all()
     serializer_class = ReleaseTypeSerializer
     filter_class = filters.ReleaseTypeFilter
+    permission_classes = (APIPermission,)
 
     def list(self, request, *args, **kwargs):
         """
@@ -995,6 +996,7 @@ class VariantTypeViewSet(StrictQueryParamMixin,
     # TODO: remove this class after next release
     serializer_class = VariantTypeSerializer
     queryset = models.VariantType.objects.all().order_by('id')
+    permission_classes = (APIPermission,)
 
     def list(self, request, *args, **kwargs):
         """
@@ -1011,6 +1013,7 @@ class ReleaseVariantTypeViewSet(StrictQueryParamMixin,
     """
     serializer_class = VariantTypeSerializer
     queryset = models.VariantType.objects.all()
+    permission_classes = (APIPermission,)
 
     def list(self, request, *args, **kwargs):
         """
@@ -1038,6 +1041,7 @@ class ReleaseGroupsViewSet(ChangeSetModelMixin,
     lookup_field = 'name'
     lookup_value_regex = '[^/]+'
     filter_class = filters.ReleaseGroupFilter
+    permission_classes = (APIPermission,)
 
     def create(self, request, *args, **kwargs):
         """

--- a/pdc/apps/repository/views.py
+++ b/pdc/apps/repository/views.py
@@ -247,6 +247,7 @@ class RepoFamilyViewSet(StrictQueryParamMixin,
     queryset = models.RepoFamily.objects.all().order_by('id')
     serializer_class = serializers.RepoFamilySerializer
     filter_class = filters.RepoFamilyFilter
+    permission_classes = (APIPermission,)
 
     def list(self, request, *args, **kwargs):
         """
@@ -296,6 +297,7 @@ class ContentCategoryViewSet(StrictQueryParamMixin,
     """
     serializer_class = serializers.ContentCategorySerializer
     queryset = models.ContentCategory.objects.all().order_by('id')
+    permission_classes = (APIPermission,)
 
     def list(self, request, *args, **kwargs):
         """
@@ -318,6 +320,7 @@ class ContentFormatViewSet(StrictQueryParamMixin,
     """
     serializer_class = serializers.ContentFormatSerializer
     queryset = models.ContentFormat.objects.all().order_by('id')
+    permission_classes = (APIPermission,)
 
     def list(self, request, *args, **kwargs):
         """
@@ -340,6 +343,7 @@ class ServiceViewSet(StrictQueryParamMixin,
     """
     serializer_class = serializers.ServiceSerializer
     queryset = models.Service.objects.all().order_by('id')
+    permission_classes = (APIPermission,)
 
     def list(self, request, *args, **kwargs):
         """

--- a/pdc/apps/utils/utils.py
+++ b/pdc/apps/utils/utils.py
@@ -7,6 +7,7 @@ import re
 
 from pdc.apps.common.hacks import validate_model
 from pdc.apps.common.constants import PDC_WARNING_HEADER_NAME
+from django.conf import settings
 from django.db.models.signals import pre_save
 from django.forms.models import model_to_dict
 
@@ -49,3 +50,7 @@ def convert_method_to_action(method):
             'retrieve': 'read',
             'create': 'create',
             'destroy': 'delete'}.get(method)
+
+
+def read_permission_for_all():
+    return hasattr(settings, 'ALLOW_ALL_USER_READ') and settings.ALLOW_ALL_USER_READ


### PR DESCRIPTION
1. Put permission control on some resources that only
   have read method. Because PDC currently grant users
   read permission in default, these APIs should be treated
   as others.
2. If user is granted read permission by configurations,
   display the correct permissions in real.
3. auth/current-user and auth/current-user are still not
   included in permission control

JIRA: PDC-1543