### PR TITLE
Create new API of compose-tree-rtt-tests

### DIFF
--- a/pdc/apps/compose/filters.py
+++ b/pdc/apps/compose/filters.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ValidationError
 
 from pdc.apps.common.filters import value_is_not_empty, MultiValueFilter, CaseInsensitiveBooleanFilter, \
     MultiValueCaseInsensitiveFilter
-from .models import Compose, OverrideRPM, ComposeTree, ComposeImage
+from .models import Compose, OverrideRPM, ComposeTree, ComposeImage, VariantArch
 
 
 class ComposeFilter(django_filters.FilterSet):
@@ -94,6 +94,17 @@ class ComposeTreeFilter(django_filters.FilterSet):
     class Meta:
         model = ComposeTree
         fields = ('compose', 'variant', 'arch', 'location', 'scheme')
+
+
+class ComposeTreeRTTTestFilter(django_filters.FilterSet):
+    compose         = MultiValueFilter(name='variant__compose__compose_id')
+    variant         = MultiValueFilter(name='variant__variant_uid')
+    arch            = MultiValueFilter(name='arch__name')
+    test_result     = MultiValueFilter(name='rtt_testing_status__name')
+
+    class Meta:
+        model = VariantArch
+        fields = ('compose', 'variant', 'arch', 'test_result')
 
 
 class ComposeImageRTTTestFilter(django_filters.FilterSet):

--- a/pdc/apps/compose/models.py
+++ b/pdc/apps/compose/models.py
@@ -219,6 +219,14 @@ class VariantArch(models.Model):
     def __unicode__(self):
         return u"%s.%s" % (self.variant, self.arch)
 
+    def export(self):
+        return {
+            "compose": self.variant.compose.compose_id,
+            "variant": self.variant.variant_uid,
+            "arch": self.arch.name,
+            "rtt_testing_status": self.rtt_testing_status.name
+        }
+
 
 class Path(models.Model):
     """

--- a/pdc/apps/compose/routers.py
+++ b/pdc/apps/compose/routers.py
@@ -37,5 +37,7 @@ router.register('rpc/compose-full-import',
                 base_name='composefullimport')
 router.register(r'compose-tree-locations', views.ComposeTreeViewSet,
                 base_name='composetreelocations')
+router.register(r'compose-tree-rtt-tests', views.ComposeTreeRTTTestVewSet,
+                base_name='composetreertttests')
 router.register(r'compose-image-rtt-tests', views.ComposeImageRTTTestViewSet,
                 base_name='composeimagertttests')

--- a/pdc/apps/compose/serializers.py
+++ b/pdc/apps/compose/serializers.py
@@ -10,7 +10,8 @@ from pdc.apps.common.models import Arch
 from pdc.apps.common.serializers import StrictSerializerMixin, DynamicFieldsSerializerMixin
 from pdc.apps.common.fields import ChoiceSlugField
 from .models import (Compose, OverrideRPM, ComposeAcceptanceTestingState,
-                     ComposeTree, Variant, Location, Scheme, ComposeImage)
+                     ComposeTree, Variant, Location, Scheme, ComposeImage,
+                     VariantArch)
 from pdc.apps.release.models import Release
 from pdc.apps.utils.utils import urldecode
 from pdc.apps.repository.models import ContentCategory
@@ -152,6 +153,20 @@ class ComposeTreeSerializer(StrictSerializerMixin,
         else:
             raise serializers.ValidationError('The combination with compose %s, variant %s, arch %s does not exist' %
                                               (compose, variant, arch))
+
+
+class ComposeTreeRTTTestSerializer(StrictSerializerMixin,
+                                   DynamicFieldsSerializerMixin,
+                                   serializers.ModelSerializer):
+    compose                 = serializers.CharField(source='variant.compose.compose_id', read_only=True)
+    variant                 = ComposeTreeVariantField(read_only=True)
+    arch                    = serializers.CharField(source='arch.name', read_only=True)
+    test_result             = ChoiceSlugField(source='rtt_testing_status', slug_field='name',
+                                              queryset=ComposeAcceptanceTestingState.objects.all())
+
+    class Meta:
+        model = VariantArch
+        fields = ('compose', 'variant', 'arch', 'test_result')
 
 
 class ComposeImageRTTTestSerializer(StrictSerializerMixin,


### PR DESCRIPTION
In Compose API, the paramenter of rtt_tested_architectures is deeply nested
and hard to use/filter etc. So we want to create compose-tree-rtt-tests
endpoint which would only do RTT tests - nothing else.

JIRA: PDC-1316