### PR TITLE
Specify Django version less than 1.9 in spec file.

### DIFF
--- a/pdc.spec
+++ b/pdc.spec
@@ -13,7 +13,7 @@ Source0:        %{name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildRequires:  python-setuptools
 BuildRequires:  python-sphinx
-Requires:       Django >= 1.8.1
+Requires:       Django >= 1.8.1, Django < 1.9.0
 Requires:       django-rest-framework >= 3.1
 Requires:       django-rest-framework < 3.2
 Requires:       django-mptt >= 0.7.1


### PR DESCRIPTION
JIRA: PDC-1559