### PR TITLE
Take keys into acount for ordering of all APIs

### DIFF
--- a/contrib/drf_introspection/__init__.py
+++ b/contrib/drf_introspection/__init__.py
@@ -31,7 +31,8 @@ def get_allowed_query_params(view):
     allowed_keys.update(getattr(view.__class__, 'filter_fields', []))
     # Take extra params specified on viewset.
     allowed_keys.update(getattr(view.__class__, 'extra_query_params', []))
-
+    # add ordering key to allowed_keys params
+    allowed_keys.update(['ordering'])
     # Add pagination param.
     if hasattr(view, 'paginator'):
         page = getattr(view.paginator, 'page_query_param', None)

--- a/pdc/apps/common/viewsets.py
+++ b/pdc/apps/common/viewsets.py
@@ -195,13 +195,21 @@ class StrictQueryParamMixin(object):
         extra_keys = set(request.query_params.keys()) - allowed_keys
         if extra_keys:
             raise FieldError('Unknown query params: %s.' % ', '.join(sorted(extra_keys)))
-
         # If 'ordering' in query parameter, check the key whether in fields.
         if 'ordering' in request.query_params.keys():
-            if request.query_params.get('ordering') not in self.__class__.serializer_class.Meta.fields:
+            self._check_ordering_keys(request)
+
+    def _check_ordering_keys(self, request):
+        ordering_keys = request.query_params.get('ordering')
+        tmp_list = []
+        if ordering_keys.startswith('-'):
+            tmp_list.append(ordering_keys.lstrip('-'))
+        else:
+            tmp_list += ordering_keys.split(',')
+        for key in tmp_list:
+            if key not in self.serializer_class.Meta.fields:
                 raise FieldError('Unknown query key: %s not in fields: %s' %
-                                 (request.query_params.get('ordering'),
-                                  self.__class__.serializer_class.Meta.fields))
+                                 (key, self.serializer_class.Meta.fields))
 
 
 class PermissionMixin(object):

--- a/pdc/apps/common/viewsets.py
+++ b/pdc/apps/common/viewsets.py
@@ -201,15 +201,11 @@ class StrictQueryParamMixin(object):
 
     def _check_ordering_keys(self, request):
         ordering_keys = request.query_params.get('ordering')
-        tmp_list = []
-        if ordering_keys.startswith('-'):
-            tmp_list.append(ordering_keys.lstrip('-'))
-        else:
-            tmp_list += ordering_keys.split(',')
-        for key in tmp_list:
-            if key not in self.serializer_class.Meta.fields:
-                raise FieldError('Unknown query key: %s not in fields: %s' %
-                                 (key, self.serializer_class.Meta.fields))
+        tmp_list = [param.strip().lstrip('-') for param in ordering_keys.split(',')]
+        invalid_fields = set(tmp_list) - set(self.serializer_class.Meta.fields)
+        if invalid_fields:
+            raise FieldError('Unknown query key: %s not in fields: %s' %
+                             (invalid_fields, self.serializer_class.Meta.fields))
 
 
 class PermissionMixin(object):

--- a/pdc/apps/compose/views.py
+++ b/pdc/apps/compose/views.py
@@ -562,6 +562,8 @@ class ComposeViewSet(StrictQueryParamMixin,
         query params, the last one will take effect.
         """
         self.order_queryset = True
+        if 'ordering' in self.request.query_params.keys():
+            self.order_queryset = False
         queryset = self.filter_queryset(self.get_queryset())
         page = self.paginate_queryset(queryset)
 

--- a/pdc/apps/release/fixtures/tests/release_groups.json
+++ b/pdc/apps/release/fixtures/tests/release_groups.json
@@ -4,7 +4,7 @@
     "pk": 1,
     "fields": {
       "name": "rhel_test",
-      "description": "good",
+      "description": "test",
       "type": 1,
       "releases": [1],
       "active": true
@@ -15,7 +15,7 @@
     "pk": 2,
     "fields": {
       "name": "rhel_test1",
-      "description": "test",
+      "description": "good",
       "type": 2,
       "releases": [1],
       "active": true

--- a/pdc/apps/release/tests.py
+++ b/pdc/apps/release/tests.py
@@ -1849,6 +1849,26 @@ class ReleaseGroupRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response1.status_code, status.HTTP_200_OK)
         self.assertEquals(response1.data.get('results')[0], expect_result1)
 
+    def test_override_ordering_with_both_character(self):
+        response = self.client.get(reverse("releasegroups-list"), format='json')
+        expect_result = {'active': True, 'type': u'Async',
+                         'name': u'rhel_test', 'releases': [u'release-1.0'],
+                         'description': u'test'}
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEquals(response.data.get('results')[0], expect_result)
+
+        url = reverse("releasegroups-list")
+        response = self.client.get(url + '?ordering=type,-description')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEquals(response.data.get('results')[0], expect_result)
+
+        response = self.client.get(url + '?ordering=description,-type')
+        expect_result = {'active': True, 'type': u'QuarterlyUpdate',
+                         'name': u'rhel_test1', 'releases': [u'release-1.0'],
+                         'description': u'good'}
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEquals(response.data.get('results')[0], expect_result)
+
     def test_retrieve_with_description_para(self):
         response = self.client.get(reverse("releasegroups-detail", args=["rhel_test"]),
                                    args={'description': 'good'}, format='json')

--- a/pdc/apps/release/tests.py
+++ b/pdc/apps/release/tests.py
@@ -1829,16 +1829,32 @@ class ReleaseGroupRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         response = self.client.get(reverse("releasegroups-detail", args=["rhel_test"]))
         expect_result = {'active': True, 'type': u'Async',
                          'name': u'rhel_test', 'releases': [u'release-1.0'],
-                         'description': u'good'}
+                         'description': u'test'}
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, expect_result)
+
+    def test_override_ordering_by_description_key(self):
+        response = self.client.get(reverse("releasegroups-list"), format='json')
+        expect_result = {'active': True, 'type': u'Async',
+                         'name': u'rhel_test', 'releases': [u'release-1.0'],
+                         'description': u'test'}
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEquals(response.data.get('results')[0], expect_result)
+        response1 = self.client.get(reverse("releasegroups-list"), {'ordering': 'description'},
+                                    format='json')
+        expect_result1 = {'active': True, 'type': u'QuarterlyUpdate',
+                          'name': u'rhel_test1', 'releases': [u'release-1.0'],
+                          'description': u'good'}
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        self.assertEquals(response1.data.get('results')[0], expect_result1)
 
     def test_retrieve_with_description_para(self):
         response = self.client.get(reverse("releasegroups-detail", args=["rhel_test"]),
                                    args={'description': 'good'}, format='json')
         expect_result = {'active': True, 'type': u'Async',
                          'name': u'rhel_test', 'releases': [u'release-1.0'],
-                         'description': u'good'}
+                         'description': u'test'}
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, expect_result)
 
@@ -1908,7 +1924,7 @@ class ReleaseGroupRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertNumChanges([2])
 
     def test_update(self):
-        args = {'type': 'QuarterlyUpdate', 'name': 'test_update', 'description': 'test',
+        args = {'type': 'QuarterlyUpdate', 'name': 'test_update', 'description': 'good',
                 'releases': [u'release-1.0']}
         response = self.client.put(reverse("releasegroups-detail", args=['rhel_test']),
                                    args, format='json')
@@ -1925,7 +1941,7 @@ class ReleaseGroupRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
 
     def test_update_without_type(self):
         self.test_create()
-        args = {'name': 'test_update', 'description': 'test',
+        args = {'name': 'test_update', 'description': 'good',
                 'releases': [u'release-1.0']}
         response = self.client.put(reverse("releasegroups-detail", args=['test']),
                                    args, format='json')
@@ -1933,7 +1949,7 @@ class ReleaseGroupRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
 
     def test_update_without_name(self):
         self.test_create()
-        args = {'type': 'QuarterlyUpdate', 'description': 'test',
+        args = {'type': 'QuarterlyUpdate', 'description': 'good',
                 'releases': [u'release-1.0']}
         response = self.client.put(reverse("releasegroups-detail", args=['test']),
                                    args, format='json')
@@ -1948,7 +1964,7 @@ class ReleaseGroupRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_update_with_error_release(self):
-        args = {'type': 'QuarterlyUpdate', 'name': 'test_update', 'description': 'test',
+        args = {'type': 'QuarterlyUpdate', 'name': 'test_update', 'description': 'good',
                 'releases': [u'release']}
         response = self.client.put(reverse("releasegroups-detail", args=['rhel_test']),
                                    args, format='json')

--- a/pdc/apps/release/views.py
+++ b/pdc/apps/release/views.py
@@ -374,7 +374,7 @@ class ReleaseViewSet(ChangeSetCreateModelMixin,
         """
         return super(ReleaseViewSet, self).retrieve(*args, **kwargs)
 
-    def list(self, *args, **kwargs):
+    def list(self, request, *args, **kwargs):
         """
         __Method__: GET
 
@@ -394,7 +394,9 @@ class ReleaseViewSet(ChangeSetCreateModelMixin,
         The releases themselves are ordered by short and version.
         """
         self.order_queryset = True
-        return super(ReleaseViewSet, self).list(*args, **kwargs)
+        if 'ordering' in request.query_params.keys():
+            self.order_queryset = False
+        return super(ReleaseViewSet, self).list(request, *args, **kwargs)
 
     def update(self, request, *args, **kwargs):
         """

--- a/pdc/settings.py
+++ b/pdc/settings.py
@@ -92,7 +92,8 @@ REST_FRAMEWORK = {
 
     'DEFAULT_METADATA_CLASS': 'contrib.bulk_operations.metadata.BulkMetadata',
 
-    'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
+    'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',
+                                'rest_framework.filters.OrderingFilter'),
 
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',

--- a/pdc/settings_test.py
+++ b/pdc/settings_test.py
@@ -33,7 +33,8 @@ REST_FRAMEWORK = {
 #        'rest_framework.permissions.DjangoModelPermissions'
 #    ],
 
-    'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
+    'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',
+                                'rest_framework.filters.OrderingFilter'),
 
     'DEFAULT_METADATA_CLASS': 'contrib.bulk_operations.metadata.BulkMetadata',
 


### PR DESCRIPTION
1. Add the OrderingFilter class supports simple query parameter
   controlled ordering of results.
2. This feature is availbale for these APIs which have the 'List'
   method and have the filter attribute.
3. The value which ordering key mapped is contained in given
   serializer_class field.

JIRA: PDC-1512