### PR TITLE
Update the docs and add the ordering fields

### DIFF
--- a/pdc/apps/common/renderers.py
+++ b/pdc/apps/common/renderers.py
@@ -65,6 +65,7 @@ Responses are available in JSON format.
 """
 
 URL_SPEC_RE = re.compile(r'\$(?P<type>URL|LINK):(?P<details>[^$]+)\$')
+ORDERING_STRING = "\n * `ordering` is used to override the ordering of the results, the value could be: "
 
 
 class ReadOnlyBrowsableAPIRenderer(BrowsableAPIRenderer):
@@ -140,6 +141,11 @@ class ReadOnlyBrowsableAPIRenderer(BrowsableAPIRenderer):
         macros = settings.BROWSABLE_DOCUMENT_MACROS
         if view:
             macros['FILTERS'] = get_filters(view)
+            if 'list' == method:
+                ordering_field = get_ordering_field(view, method)
+                if ordering_field:
+                    ordering_string = ORDERING_STRING + " %s ." % ordering_field
+                    macros['FILTERS'] += ordering_string
             if '%(SERIALIZER)s' in docstring:
                 macros['SERIALIZER'] = get_serializer(view, include_read_only=True)
             if '%(WRITABLE_SERIALIZER)s' in docstring:
@@ -172,6 +178,22 @@ class ReadOnlyBrowsableAPIRenderer(BrowsableAPIRenderer):
                              exc_info=sys.exc_info())
                 return 'BAD URL'
         return URL_SPEC_RE.sub(replace_url, text)
+
+
+def get_ordering_field(view, method):
+    """ If the APIs have the LIST method; for the view of LIST method, add the
+    Ordering field for the users.
+    """
+    if 'list' in method and view.serializer_class:
+        model_fields = [field.name for field in view.queryset.model._meta.fields]
+        serializer_fields = [
+            field.source or field_name
+            for field_name, field in view.serializer_class().fields.items()
+            if not getattr(field, 'write_only', False)]
+        valid_fields = list(set(model_fields).intersection(set(serializer_fields)))
+        return valid_fields
+    else:
+        return None
 
 
 FILTERS_CACHE = {}


### PR DESCRIPTION
When override the ordering of the results, some changes happened;
as followed:
1, Update the ordering fields. the ordering fields are the intersection
of Model fields and Serializer fields.
2. To make the ordering fields more friendly and clearly for customers,
add the ordering fields in docs, which share in page of 'LIST' method.

JIRA:PDC-1659