### PR TITLE
Use slug in release / product version / product URLs.

### DIFF
--- a/pdc/apps/release/templates/base_product_list_include.html
+++ b/pdc/apps/release/templates/base_product_list_include.html
@@ -12,7 +12,7 @@
   <tbody>
 {% for base_product in base_product_list %}
   <tr>
-    <td><a href="{% url "base_product/detail" base_product.id %}">{{ base_product }}</a></td>
+    <td><a href="{% url "base_product/detail/slug" base_product.base_product_id %}">{{ base_product }}</a></td>
     <td>{{ base_product.name }}</td>
     <td>{{ base_product.short }}</td>
     <td>{{ base_product.version }}</td>

--- a/pdc/apps/release/templates/product_list_include.html
+++ b/pdc/apps/release/templates/product_list_include.html
@@ -18,7 +18,7 @@
  <tbody>
 {% for product in product_list %}
   <tr>
-    <td><a href="{% url "product/detail" product.id %}">{{ product.short }}</a></td>
+    <td><a href="{% url "product/detail/slug" product.short %}">{{ product.short }}</a></td>
     <td>{{ product.name }}</td>
     <td>{{ product.active }}</td>
     <td>{{ product.active_product_version_count }} / {{ product.product_version_count }}</td>

--- a/pdc/apps/release/templates/product_version_list_include.html
+++ b/pdc/apps/release/templates/product_version_list_include.html
@@ -19,7 +19,7 @@
  <tbody>
 {% for version in product_version_list %}
   <tr>
-    <td><a href="{% url "product_version/detail" version.id %}">{{ version.product_version_id }}</a></td>
+    <td><a href="{% url "product_version/detail/slug" version.product_version_id %}">{{ version.product_version_id }}</a></td>
     <td>{{ version.name }}</td>
     <td>{{ version.short }}</td>
     <td>{{ version.version }}</td>

--- a/pdc/apps/release/templates/release_detail.html
+++ b/pdc/apps/release/templates/release_detail.html
@@ -33,7 +33,7 @@
 {% if release.base_product %}
     <dt>{% trans "Base Product" %}</dt>
     <dd>
-      <a href="{% url "base_product/detail" release.base_product.id %}">
+      <a href="{% url "base_product/detail/slug" release.base_product.base_product_id %}">
         {{ release.base_product.name }} ({{ release.base_product }})
       </a>
     </dd>
@@ -59,9 +59,9 @@
     <td>
         {{ variant.variant_uid }}
         {% if variant.integrated_from %}
-            <span class="pull-right">(integrated from <a href="{% url "release/detail" variant.integrated_from.id %}">{{ variant.integrated_from.release_id }}</a>)</span>
+            <span class="pull-right">(integrated from <a href="{% url "release/detail/slug" variant.integrated_from.release_id %}">{{ variant.integrated_from.release_id }}</a>)</span>
         {% elif variant.integrated_to %}
-            <span class="pull-right">(integrated to <a href="{% url "release/detail" variant.integrated_to.id %}">{{ variant.integrated_to }}</a>)</span>
+            <span class="pull-right">(integrated to <a href="{% url "release/detail/slug" variant.integrated_to.release_id %}">{{ variant.integrated_to }}</a>)</span>
         {% endif %}
     </td>
     <td>{{ variant.variant_id }}</td>

--- a/pdc/apps/release/templates/release_list_include.html
+++ b/pdc/apps/release/templates/release_list_include.html
@@ -21,14 +21,14 @@
  <tbody>
 {% for release in release_list %}
   <tr>
-    <td><a href="{% url "release/detail" release.id %}">{{ release.release_id }}</a></td>
+    <td><a href="{% url "release/detail/slug" release.release_id %}">{{ release.release_id }}</a></td>
     <td>{{ release.name }}</td>
     <td>{{ release.short }}</td>
     <td>{{ release.version }}</td>
-    <td>{% if release.base_product %}<a href="{% url "base_product/detail" release.base_product.id %}">{{ release.base_product }}</a>{% endif %}</td>
+    <td>{% if release.base_product %}<a href="{% url "base_product/detail/slug" release.base_product.base_product_id %}">{{ release.base_product }}</a>{% endif %}</td>
     <td>
         {% if release.product_version %}
-            <a href="{% url "product_version/detail" release.product_version.id %}">
+            <a href="{% url "product_version/detail/slug" release.product_version.product_version_id %}">
                 {{ release.product_version }}
             </a>
         {% endif %}

--- a/pdc/apps/release/views.py
+++ b/pdc/apps/release/views.py
@@ -55,6 +55,8 @@ class ReleaseDetailView(DetailView):
         .prefetch_related('variant_set__variant_type',
                           'variant_set__variantarch_set__arch')
     pk_url_kwarg = "id"
+    slug_url_kwarg = "release_id"
+    slug_field = "release_id"
     template_name = "release_detail.html"
 
     def get_context_data(self, **kwargs):
@@ -78,6 +80,8 @@ class BaseProductListView(SearchView):
 class BaseProductDetailView(DetailView):
     model = models.BaseProduct
     pk_url_kwarg = "id"
+    slug_url_kwarg = "base_product_id"
+    slug_field = "base_product_id"
     template_name = "base_product_detail.html"
     context_object_name = "base_product"
 
@@ -100,6 +104,8 @@ class ProductListView(PageSizeMixin, SearchView):
 class ProductDetailView(DetailView):
     queryset = models.Product.objects.prefetch_related('productversion_set__release_set')
     pk_url_kwarg = "id"
+    slug_url_kwarg = "short"
+    slug_field = "short"
     template_name = "product_detail.html"
     context_object_name = "product"
 
@@ -572,6 +578,8 @@ class ProductVersionListView(PageSizeMixin, SearchView):
 class ProductVersionDetailView(DetailView):
     queryset = models.ProductVersion.objects.prefetch_related('release_set__release_type')
     pk_url_kwarg = "id"
+    slug_url_kwarg = "product_version_id"
+    slug_field = "product_version_id"
     template_name = "product_version_detail.html"
     context_object_name = "product_version"
 

--- a/pdc/urls.py
+++ b/pdc/urls.py
@@ -55,12 +55,15 @@ urlpatterns = [
 
     url(r"^release/$", ReleaseListView.as_view(), name="release/index"),
     url(r"^release/(?P<id>\d+)/$", ReleaseDetailView.as_view(), name="release/detail"),
+    url(r"^release/(?P<release_id>[^/]+)/$", ReleaseDetailView.as_view(), name="release/detail/slug"),
 
     url(r"^base-product/$", BaseProductListView.as_view(), name="base_product/index"),
     url(r"^base-product/(?P<id>\d+)/$", BaseProductDetailView.as_view(), name="base_product/detail"),
+    url(r"^base-product/(?P<base_product_id>[^/]+)/$", BaseProductDetailView.as_view(), name="base_product/detail/slug"),
 
     url(r"^product/$", ProductListView.as_view(), name="product/index"),
     url(r"^product/(?P<id>\d+)/$", ProductDetailView.as_view(), name="product/detail"),
+    url(r"^product/(?P<short>[^/]+)/$", ProductDetailView.as_view(), name="product/detail/slug"),
     url(r'^product-index/$', release_views.product_pages, name='product_pages'),
 
     url(r"^product-version/$",
@@ -69,6 +72,9 @@ urlpatterns = [
     url(r"^product-version/(?P<id>\d+)/$",
         ProductVersionDetailView.as_view(),
         name="product_version/detail"),
+    url(r"^product-version/(?P<product_version_id>[^/]+)/$",
+        ProductVersionDetailView.as_view(),
+        name="product_version/detail/slug"),
 
     url(r"^%s%s/" % (settings.REST_API_URL, settings.REST_API_VERSION), include(router.urls)),
 


### PR DESCRIPTION
When using multiple PDC instances, it's difficult to preserve URLs,
since the IDs for a release/productversion/product can differ.
Using slug field solves the problem.