### PR TITLE
Fix apps loading in Django 1.9.

### DIFF
--- a/pdc/apps/bindings/apps.py
+++ b/pdc/apps/bindings/apps.py
@@ -4,7 +4,6 @@
 # http://opensource.org/licenses/MIT
 #
 from django.apps import AppConfig
-from pdc.apps.utils.utils import connect_app_models_pre_save_signal
 
 
 class BindingsConfig(AppConfig):
@@ -19,6 +18,7 @@ class BindingsConfig(AppConfig):
         self._connect_signals()
 
     def _connect_signals(self):
+        from pdc.apps.utils.utils import connect_app_models_pre_save_signal
         models_name = ('ReleaseBugzillaMapping', 'ReleaseDistGitMapping', 'ReleaseComponentSRPMNameMapping')
         connect_app_models_pre_save_signal(self, [self.get_model(model_name) for model_name in models_name])
 

--- a/pdc/apps/common/apps.py
+++ b/pdc/apps/common/apps.py
@@ -4,7 +4,6 @@
 # http://opensource.org/licenses/MIT
 #
 from django.apps import AppConfig
-from pdc.apps.utils.utils import connect_app_models_pre_save_signal
 
 
 class CommonAppConfig(AppConfig):
@@ -13,4 +12,5 @@ class CommonAppConfig(AppConfig):
     verbose_name = 'Common App'
 
     def ready(self):
+        from pdc.apps.utils.utils import connect_app_models_pre_save_signal
         connect_app_models_pre_save_signal(self)

--- a/pdc/apps/component/apps.py
+++ b/pdc/apps/component/apps.py
@@ -4,7 +4,6 @@
 # http://opensource.org/licenses/MIT
 #
 from django.apps import AppConfig
-from pdc.apps.utils.utils import connect_app_models_pre_save_signal
 
 
 class ComponentConfig(AppConfig):
@@ -12,4 +11,5 @@ class ComponentConfig(AppConfig):
     verbose_name = 'Component App'
 
     def ready(self):
+        from pdc.apps.utils.utils import connect_app_models_pre_save_signal
         connect_app_models_pre_save_signal(self)

--- a/pdc/apps/compose/apps.py
+++ b/pdc/apps/compose/apps.py
@@ -4,11 +4,11 @@
 # http://opensource.org/licenses/MIT
 #
 from django.apps import AppConfig
-from pdc.apps.utils.utils import connect_app_models_pre_save_signal
 
 
 class ComposeConfig(AppConfig):
     name = 'pdc.apps.compose'
 
     def ready(self):
+        from pdc.apps.utils.utils import connect_app_models_pre_save_signal
         connect_app_models_pre_save_signal(self)

--- a/pdc/apps/contact/apps.py
+++ b/pdc/apps/contact/apps.py
@@ -4,12 +4,12 @@
 # http://opensource.org/licenses/MIT
 #
 from django.apps import AppConfig
-from pdc.apps.utils.utils import connect_app_models_pre_save_signal
 
 
 class ContactConfig(AppConfig):
     name = 'pdc.apps.contact'
 
     def ready(self):
+        from pdc.apps.utils.utils import connect_app_models_pre_save_signal
         connect_app_models_pre_save_signal(self)
         from . import signals   # noqa

--- a/pdc/apps/package/apps.py
+++ b/pdc/apps/package/apps.py
@@ -4,11 +4,11 @@
 # http://opensource.org/licenses/MIT
 #
 from django.apps import AppConfig
-from pdc.apps.utils.utils import connect_app_models_pre_save_signal
 
 
 class PackageConfig(AppConfig):
     name = 'pdc.apps.package'
 
     def ready(self):
+        from pdc.apps.utils.utils import connect_app_models_pre_save_signal
         connect_app_models_pre_save_signal(self)

--- a/pdc/apps/release/apps.py
+++ b/pdc/apps/release/apps.py
@@ -4,13 +4,13 @@
 # http://opensource.org/licenses/MIT
 #
 from django.apps import AppConfig
-from pdc.apps.utils.utils import connect_app_models_pre_save_signal
 
 
 class ReleaseConfig(AppConfig):
     name = 'pdc.apps.release'
 
     def ready(self):
+        from pdc.apps.utils.utils import connect_app_models_pre_save_signal
         models_name = ('ReleaseType', 'BaseProduct', 'Product', 'ProductVersion', 'Release', 'VariantType',
                        'Variant', 'VariantArch')
         connect_app_models_pre_save_signal(self, [self.get_model(model_name) for model_name in models_name])

--- a/pdc/apps/repository/apps.py
+++ b/pdc/apps/repository/apps.py
@@ -4,11 +4,11 @@
 # http://opensource.org/licenses/MIT
 #
 from django.apps import AppConfig
-from pdc.apps.utils.utils import connect_app_models_pre_save_signal
 
 
 class RepositoryConfig(AppConfig):
     name = 'pdc.apps.repository'
 
     def ready(self):
+        from pdc.apps.utils.utils import connect_app_models_pre_save_signal
         connect_app_models_pre_save_signal(self)


### PR DESCRIPTION
Fixes: django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
The fix only moves signal imports under ready() method.
