### PR TITLE
Make release components be unique by name/release/type.

### DIFF
--- a/pdc/apps/component/migrations/0012_auto_20160928_1838.py
+++ b/pdc/apps/component/migrations/0012_auto_20160928_1838.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('component', '0011_auto_20151126_0602'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='releasecomponent',
+            unique_together=set([('release', 'name', 'type')]),
+        ),
+    ]

--- a/pdc/apps/component/models.py
+++ b/pdc/apps/component/models.py
@@ -151,7 +151,7 @@ class ReleaseComponent(models.Model):
 
     class Meta:
         unique_together = [
-            ("release", "name"),
+            ("release", "name", "type"),
         ]
 
     def __unicode__(self):

--- a/pdc/apps/component/serializers.py
+++ b/pdc/apps/component/serializers.py
@@ -181,7 +181,7 @@ class ReleaseComponentSerializer(DynamicFieldsSerializerMixin,
     bugzilla_component = TreeForeignKeyField(read_only=False, required=False, allow_null=True)
     brew_package = serializers.CharField(required=False)
     active = serializers.BooleanField(required=False, default=True)
-    type = ChoiceSlugField(slug_field='name', queryset=ReleaseComponentType.objects.all(), required=False)
+    type = ChoiceSlugField(slug_field='name', queryset=ReleaseComponentType.objects.all(), required=False, default=lambda: ReleaseComponentType.objects.get(name='rpm'))
 
     def update(self, instance, validated_data):
         signals.releasecomponent_serializer_extract_data.send(sender=self, validated_data=validated_data)

--- a/pdc/apps/component/tests.py
+++ b/pdc/apps/component/tests.py
@@ -569,6 +569,14 @@ class ReleaseComponentRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertNumChanges([])
 
+    def test_create_release_component_with_type_extended_unique_together_fields(self):
+        # python27 already exists as an rpm, ensure we can add it as container.
+        url = reverse('releasecomponent-list')
+        data = {'release': 'release-1.0', 'global_component': 'python', 'name': 'python27', 'brew_package': 'python-pdc', 'type': 'container'}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertNumChanges([1])
+
     def test_create_release_component_for_non_existing_release(self):
         url = reverse('releasecomponent-list')
         data = {'release': 'hello-1.0',


### PR DESCRIPTION
This used to consider only `name` and `release`, which makes a certain
amount of sense.  We don't want more than one rpm with the same name in
the same release entry here.

However, if we open this up to start handling other types of release
components like `container` or `module`, then it is easy to imagine that
we might have one "cockpit" rpm in a release but also a "cockpit"
container in the same release.

If you try to create both of those entries in PDC, it will fail saying
that "name and release must be unique".  This change fixes that by
loosening the uniqueness constraint to also take `type` into account.