### PR TITLE
Remove unneeded django-jsonfield dependency

### DIFF
--- a/pdc.spec
+++ b/pdc.spec
@@ -30,7 +30,6 @@ Requires:       python-mock
 Requires:       python-psycopg2
 Requires:       python-django-cors-headers
 Requires:       python-django-rest-framework-composed-permissions
-Requires:       python-django-jsonfield
 
 %description
 The Product Definition Center, at its core, is a database that defines every Red Hat products, and their relationships with several important entities.

--- a/pdc/apps/module/migrations/0001_initial.py
+++ b/pdc/apps/module/migrations/0001_initial.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
-import jsonfield.fields
 
 
 class Migration(migrations.Migration):

--- a/requirements/devel.txt
+++ b/requirements/devel.txt
@@ -16,4 +16,3 @@ lxml
 pygraphviz
 # docs
 Sphinx
-django-jsonfield

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -9,4 +9,3 @@ django-filter==0.9.2
 django-mptt>=0.7.1
 django-cors-headers
 djangorestframework-composed-permissions
-django-jsonfield


### PR DESCRIPTION
JIRA: PDC-2082

---
Strange that pylint nor flake8 tool don't warn about this unused import.