### PR TITLE
Add CPE field to release-variant endpoint

### DIFF
--- a/pdc/apps/release/filters.py
+++ b/pdc/apps/release/filters.py
@@ -6,7 +6,7 @@
 import django_filters
 
 from pdc.apps.common import filters
-from .models import Release, ProductVersion, Product, ReleaseType, Variant, BaseProduct, ReleaseGroup
+from .models import Release, ProductVersion, Product, ReleaseType, Variant, VariantCPE, BaseProduct, ReleaseGroup
 
 
 class ActiveReleasesFilter(filters.CaseInsensitiveBooleanFilter):
@@ -110,6 +110,16 @@ class ReleaseVariantFilter(django_filters.FilterSet):
     class Meta:
         model = Variant
         fields = ('release', 'id', 'uid', 'name', 'type')
+
+
+class ReleaseVariantCPEFilter(django_filters.FilterSet):
+    release = filters.MultiValueFilter(name='variant__release__release_id')
+    variant_uid = filters.MultiValueFilter(name='variant__variant_uid')
+    cpe = filters.MultiValueFilter(name='cpe')
+
+    class Meta:
+        model = VariantCPE
+        fields = ('release', 'variant_uid', 'cpe')
 
 
 class ReleaseGroupFilter(django_filters.FilterSet):

--- a/pdc/apps/release/migrations/0009_variantcpe.py
+++ b/pdc/apps/release/migrations/0009_variantcpe.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('release', '0008_auto_20160719_1221'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='VariantCPE',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('cpe', models.CharField(max_length=300)),
+                ('variant', models.OneToOneField(to='release.Variant')),
+            ],
+        ),
+    ]

--- a/pdc/apps/release/models.py
+++ b/pdc/apps/release/models.py
@@ -323,7 +323,24 @@ class Variant(models.Model):
             'variant_uid': self.variant_uid,
             'variant_name': self.variant_name,
             'variant_type': self.variant_type.name,
-            'arches': self.arches,
+            'arches': self.arches
+        }
+
+
+class VariantCPE(models.Model):
+    """
+    CPE for release variant.
+    """
+    variant = models.OneToOneField(Variant)
+
+    # CPE (https://cpe.mitre.org/)
+    cpe = models.CharField(max_length=300, blank=False, null=False)
+
+    def export(self):
+        return {
+            'release': self.variant.release.release_id,
+            'variant_uid': self.variant.variant_uid,
+            'cpe': self.cpe,
         }
 
 

--- a/pdc/apps/release/routers.py
+++ b/pdc/apps/release/routers.py
@@ -30,6 +30,8 @@ router.register(r'rpc/release/clone-components',
                 )
 router.register(r'release-variants',
                 views.ReleaseVariantViewSet)
+router.register(r'variant-cpes',
+                views.ReleaseVariantCPEViewSet)
 router.register(r'release-variant-types', views.ReleaseVariantTypeViewSet,
                 base_name='releasevarianttype')
 

--- a/pdc/apps/release/views.py
+++ b/pdc/apps/release/views.py
@@ -20,7 +20,7 @@ from .forms import (ReleaseSearchForm, BaseProductSearchForm,
 from .models import ProductVersion, Release, BaseProduct, Variant, Product
 from .serializers import (ProductSerializer, ProductVersionSerializer,
                           ReleaseSerializer, BaseProductSerializer,
-                          ReleaseTypeSerializer, ReleaseVariantSerializer,
+                          ReleaseTypeSerializer, ReleaseVariantSerializer, ReleaseVariantCPESerializer,
                           VariantTypeSerializer, ReleaseGroupSerializer)
 from pdc.apps.compose import models as compose_models
 from pdc.apps.repository import models as repo_models
@@ -1010,6 +1010,101 @@ class ReleaseVariantViewSet(ChangeSetModelMixin,
         __URL__: $LINK:variant-detail:release_id}/{variant_uid$
         """
         return super(ReleaseVariantViewSet, self).destroy(*args, **kwargs)
+
+
+class ReleaseVariantCPEViewSet(ChangeSetModelMixin,
+                               ConditionalProcessingMixin,
+                               StrictQueryParamMixin,
+                               MultiLookupFieldMixin,
+                               viewsets.GenericViewSet):
+    """
+    Common Platform Enumeration (CPE) for $LINK:variant-list$.
+
+    CPE is a standardized method of describing and identifying classes of operating systems.
+
+    Common Vulnerabilities and Exposures (CVE) contain list of affected CPEs.
+
+    For more information about CPE see [cpe.mitre.org](https://cpe.mitre.org/).
+    """
+
+    queryset = models.VariantCPE.objects.all()
+    serializer_class = ReleaseVariantCPESerializer
+    filter_class = filters.ReleaseVariantCPEFilter
+    permission_classes = (APIPermission,)
+    lookup_fields = (('variant__release__release_id', r'[^/]+'), ('variant__variant_uid', r'[^/]+'))
+
+    def create(self, request, *args, **kwargs):
+        """
+        __Method__: POST
+
+        __URL__: $LINK:variantcpe-list$
+
+        __Data__:
+
+        %(WRITABLE_SERIALIZER)s
+
+        __Response__:
+
+        %(SERIALIZER)s
+        """
+
+        return super(ReleaseVariantCPEViewSet, self).create(request, *args, **kwargs)
+
+    def retrieve(self, request, *args, **kwargs):
+        """
+        __Method__: GET
+
+        __URL__: $LINK:variantcpe-detail:release_id}/{variant_uid$
+
+        __Response__:
+
+        %(SERIALIZER)s
+        """
+        return super(ReleaseVariantCPEViewSet, self).retrieve(request, *args, **kwargs)
+
+    def list(self, *args, **kwargs):
+        """
+        __Method__: GET
+
+        __URL__: $LINK:variantcpe-list$
+
+        __Query params__:
+
+        %(FILTERS)s
+
+        __Response__: a paged list of following objects
+
+        %(SERIALIZER)s
+        """
+        return super(ReleaseVariantCPEViewSet, self).list(*args, **kwargs)
+
+    def update(self, request, *args, **kwargs):
+        """
+        __Method__: PUT, PATCH
+
+        __URL__: $LINK:variantcpe-detail:release_id}/{variant_uid$
+
+        __Data__:
+
+        %(WRITABLE_SERIALIZER)s
+
+        __Response__:
+
+        %(SERIALIZER)s
+        """
+        return super(ReleaseVariantCPEViewSet, self).update(request, *args, **kwargs)
+
+    def destroy(self, *args, **kwargs):
+        """
+        __Method__: `DELETE`
+
+        __URL__: $LINK:variantcpe-detail:release_id}/{variant_uid$
+
+        __Response__:
+
+        On success, HTTP status code is 204 and the response has no content.
+        """
+        return super(ReleaseVariantCPEViewSet, self).destroy(*args, **kwargs)
 
 
 class VariantTypeViewSet(StrictQueryParamMixin,


### PR DESCRIPTION
Adds new model binding CPE to release-variant because the permission to
change CPE should be left only to authorized person (security team).

JIRA: PDC-1319

---

CPE in the `release-variants` listing but it's only backreference from `VariantCPE` model (`variant-cpes` in API) so it cannot be changed from `release-variants` which makes it possible to set different permissions.