### PR TITLE
Pdc 1895 push targets

### DIFF
--- a/pdc/apps/release/fixtures/tests/allowed_push_targets.json
+++ b/pdc/apps/release/fixtures/tests/allowed_push_targets.json
@@ -1,0 +1,127 @@
+[
+    {
+        "model": "release.Product",
+        "pk": 1,
+        "fields": {
+            "name": "Test Product",
+            "short": "product",
+            "allowed_push_targets": [
+                1,
+                2
+            ]
+        }
+    },
+    {
+        "model": "release.Product",
+        "pk": 2,
+        "fields": {
+            "name": "Test Product 2",
+            "short": "product2",
+            "allowed_push_targets": [
+                3
+            ]
+        }
+    },
+
+    {
+        "model": "release.ProductVersion",
+        "pk": 1,
+        "fields": {
+            "name": "Product Version",
+            "short": "product",
+            "version": "1",
+            "product_version_id": "product-1",
+            "product": 1
+        }
+    },
+    {
+        "model": "release.ProductVersion",
+        "pk": 2,
+        "fields": {
+            "name": "Product Version",
+            "short": "product",
+            "version": "2",
+            "product_version_id": "product-2",
+            "product": 1
+        }
+    },
+    {
+        "model": "release.ProductVersion",
+        "pk": 3,
+        "fields": {
+            "name": "Product2 Version",
+            "short": "product2",
+            "version": "1",
+            "product_version_id": "product2-1",
+            "product": 2
+        }
+    },
+
+    {
+        "model": "release.Release",
+        "pk": 1,
+        "fields": {
+            "release_type": 1,
+            "release_id": "product-1.0",
+            "name": "Our Awesome Product",
+            "product_version": 1,
+            "short": "product",
+            "version": "1.0",
+            "active": true,
+            "base_product": null
+        }
+    },
+    {
+        "model": "release.Release",
+        "pk": 2,
+        "fields": {
+            "release_type": 1,
+            "release_id": "product-2.0",
+            "name": "Our Awesome Product",
+            "product_version": 2,
+            "short": "product",
+            "version": "2.0",
+            "active": true,
+            "base_product": null
+        }
+    },
+    {
+        "model": "release.Release",
+        "pk": 3,
+        "fields": {
+            "release_type": 1,
+            "release_id": "product2-1.0",
+            "name": "Our Awesome Product",
+            "product_version": 3,
+            "short": "product2",
+            "version": "1.0",
+            "active": true,
+            "base_product": null
+        }
+    },
+
+    {
+        "model": "release.Variant",
+        "pk": 1,
+        "fields": {
+            "release": 1,
+            "variant_id": "Server",
+            "variant_type": 1,
+            "deleted": false,
+            "variant_name": "Server",
+            "variant_uid": "Server"
+        }
+    },
+    {
+        "model": "release.Variant",
+        "pk": 2,
+        "fields": {
+            "release": 3,
+            "variant_id": "Server",
+            "variant_type": 1,
+            "deleted": false,
+            "variant_name": "Server",
+            "variant_uid": "Server"
+        }
+    }
+]

--- a/pdc/apps/release/migrations/0014_auto_20170922_0804.py
+++ b/pdc/apps/release/migrations/0014_auto_20170922_0804.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('repository', '0003_pushtarget'),
+        ('release', '0013_release_allowed_debuginfos'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='product',
+            name='allowed_push_targets',
+            field=models.ManyToManyField(to='repository.PushTarget'),
+        ),
+        migrations.AddField(
+            model_name='productversion',
+            name='masked_push_targets',
+            field=models.ManyToManyField(to='repository.PushTarget'),
+        ),
+        migrations.AddField(
+            model_name='release',
+            name='masked_push_targets',
+            field=models.ManyToManyField(to='repository.PushTarget'),
+        ),
+        migrations.AddField(
+            model_name='variant',
+            name='masked_push_targets',
+            field=models.ManyToManyField(to='repository.PushTarget'),
+        ),
+    ]

--- a/pdc/apps/repository/filters.py
+++ b/pdc/apps/repository/filters.py
@@ -33,3 +33,14 @@ class RepoFamilyFilter(filters.FilterSet):
     class Meta:
         model = models.RepoFamily
         fields = ('name',)
+
+
+class PushTargetFilter(filters.FilterSet):
+    name = MultiValueFilter()
+    description = MultiValueFilter()
+    host = MultiValueFilter()
+    service = MultiValueFilter(name='service__name')
+
+    class Meta:
+        model = models.PushTarget
+        fields = ('name', 'description', 'service', 'host')

--- a/pdc/apps/repository/fixtures/tests/push_target.json
+++ b/pdc/apps/repository/fixtures/tests/push_target.json
@@ -1,0 +1,32 @@
+[
+    {
+        "model": "repository.PushTarget",
+        "pk": 1,
+        "fields": {
+            "name": "rhn-live",
+            "service": 1,
+            "host": "https://example.com/rhn-live",
+            "description": "RHN Live"
+        }
+    },
+    {
+        "model": "repository.PushTarget",
+        "pk": 2,
+        "fields": {
+            "name": "rhn-stage",
+            "service": 1,
+            "host": "https://example.com/rhn-live",
+            "description": "RHN Stage"
+        }
+    },
+    {
+        "model": "repository.PushTarget",
+        "pk": 3,
+        "fields": {
+            "name": "rhn-qa",
+            "service": 2,
+            "host": "https://example.com/rhn-qa",
+            "description": "RHN QA"
+        }
+    }
+]

--- a/pdc/apps/repository/migrations/0003_pushtarget.py
+++ b/pdc/apps/repository/migrations/0003_pushtarget.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('repository', '0002_auto_20150512_0724'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PushTarget',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(unique=True, max_length=100, db_index=True)),
+                ('description', models.CharField(max_length=300, blank=True)),
+                ('host', models.URLField(max_length=255, blank=True)),
+                ('service', models.ForeignKey(to='repository.Service')),
+            ],
+            options={
+                'ordering': ['name'],
+            },
+        ),
+    ]

--- a/pdc/apps/repository/models.py
+++ b/pdc/apps/repository/models.py
@@ -117,3 +117,24 @@ class Repo(models.Model):
         """Return a string representation of a tree the repo belongs to."""
         return '%s.%s' % (self.variant_arch.variant.variant_uid,
                           self.variant_arch.arch.name)
+
+
+class PushTarget(models.Model):
+    name = models.CharField(max_length=100, blank=False, db_index=True, unique=True)
+    description = models.CharField(max_length=300, blank=True)
+    host = models.URLField(max_length=255, blank=True)
+    service = models.ForeignKey(Service)
+
+    class Meta:
+        ordering = ["name"]
+
+    def __unicode__(self):
+        return u"%s" % self.name
+
+    def export(self):
+        return {
+            "name": self.name,
+            "description": self.description,
+            "host": self.host,
+            "service": self.service.name,
+        }

--- a/pdc/apps/repository/routers.py
+++ b/pdc/apps/repository/routers.py
@@ -25,3 +25,5 @@ router.register(r'content-delivery-content-formats', views.ContentFormatViewSet,
                 base_name='contentdeliverycontentformat')
 router.register(r'content-delivery-services', views.ServiceViewSet,
                 base_name='contentdeliveryservice')
+router.register(r'push-targets', views.PushTargetViewSet,
+                base_name='pushtarget')

--- a/pdc/apps/repository/serializers.py
+++ b/pdc/apps/repository/serializers.py
@@ -98,3 +98,14 @@ class ServiceSerializer(StrictSerializerMixin, serializers.ModelSerializer):
     class Meta:
         model = models.Service
         fields = ('name', 'description',)
+
+
+class PushTargetSerializer(StrictSerializerMixin, serializers.ModelSerializer):
+    name = serializers.CharField()
+    description = serializers.CharField(allow_blank=True)
+    host = serializers.CharField(allow_blank=True, required=False)
+    service = ChoiceSlugField(slug_field='name', queryset=models.Service.objects.all())
+
+    class Meta:
+        model = models.PushTarget
+        fields = ('id', 'name', 'description', 'service', 'host')

--- a/pdc/apps/repository/views.py
+++ b/pdc/apps/repository/views.py
@@ -15,7 +15,8 @@ from . import filters
 from pdc.apps.auth.permissions import APIPermission
 from pdc.apps.common.constants import PUT_OPTIONAL_PARAM_WARNING
 from pdc.apps.common.viewsets import (ChangeSetCreateModelMixin, StrictQueryParamMixin,
-                                      ChangeSetUpdateModelMixin, ChangeSetDestroyModelMixin)
+                                      ChangeSetUpdateModelMixin, ChangeSetDestroyModelMixin,
+                                      PDCModelViewSet)
 from pdc.apps.release.models import Release
 from pdc.apps.common import hacks
 from pdc.apps.common.serializers import StrictSerializerMixin
@@ -356,3 +357,87 @@ class ServiceViewSet(StrictQueryParamMixin,
         %(SERIALIZER)s
         """
         return super(ServiceViewSet, self).list(request, *args, **kwargs)
+
+
+class PushTargetViewSet(PDCModelViewSet):
+    """
+    Push targets for products, product versions, releases and release variants.
+    """
+
+    queryset = models.PushTarget.objects.all()
+    serializer_class = serializers.PushTargetSerializer
+    filter_class = filters.PushTargetFilter
+    permission_classes = (APIPermission,)
+
+    def create(self, request, *args, **kwargs):
+        """
+        __Method__: POST
+
+        __URL__: $LINK:pushtarget-list$
+
+        __Data__:
+
+        %(WRITABLE_SERIALIZER)s
+
+        __Response__:
+
+        %(SERIALIZER)s
+        """
+
+        return super(PushTargetViewSet, self).create(request, *args, **kwargs)
+
+    def retrieve(self, request, *args, **kwargs):
+        """
+        __Method__: GET
+
+        __URL__: $LINK:pushtarget-detail:instance_pk$
+
+        __Response__:
+
+        %(SERIALIZER)s
+        """
+        return super(PushTargetViewSet, self).retrieve(request, *args, **kwargs)
+
+    def list(self, *args, **kwargs):
+        """
+        __Method__: GET
+
+        __URL__: $LINK:pushtarget-list$
+
+        __Query params__:
+
+        %(FILTERS)s
+
+        __Response__: a paged list of following objects
+
+        %(SERIALIZER)s
+        """
+        return super(PushTargetViewSet, self).list(*args, **kwargs)
+
+    def update(self, request, *args, **kwargs):
+        """
+        __Method__: PUT, PATCH
+
+        __URL__: $LINK:pushtarget-detail:instance_pk$
+
+        __Data__:
+
+        %(WRITABLE_SERIALIZER)s
+
+        __Response__:
+
+        %(SERIALIZER)s
+        """
+        return super(PushTargetViewSet, self).update(request, *args, **kwargs)
+
+    def destroy(self, *args, **kwargs):
+        """
+        __Method__: `DELETE`
+
+        __URL__: $LINK:pushtarget-detail:instance_pk$
+
+        __Response__:
+
+        On success, HTTP status code is 204 and the response has no content.
+        """
+        return super(PushTargetViewSet, self).destroy(*args, **kwargs)


### PR DESCRIPTION
---
I have yet to implement tests and fix existing ones.

Field `allowed_push_targets` is implemented in products, product-versions, releases, release-variant. Only for products it's saved as-is; for other endpoints, `masked_push_targets` is stored instead but user will still only see `allowed_push_targets` in requests and responses.

Examples:
```bash
> pdc_client -r content-delivery-services
{
    "count": 3,
    "next": null,
    "previous": null,
    "results": [
        {
            "description": "Red Hat Network",
            "name": "rhn"
        },
        #...
    ]
}
> pdc_client -r push-targets -x POST \
  -d '{"description":"", "name":"rhn-stage", "service":"rhn"}'

{
    "description": "",
    "host": "",
    "id": 1,
    "name": "rhn-stage",
    "service": "rhn"
}
> pdc_client -r push-targets -x POST \
  -d '{"host":"", "description":"RHN Live", "name":"rhn-live", "service":"rhn"}'

{
    "description": "RHN Live",
    "host": "",
    "id": 2,
    "name": "rhn-live",
    "service": "rhn"
}
> pdc_client -r products/rhel
{
    "active": true,
    "name": "Red Hat Enterprise Linux",
    "product_versions": [
        "rhel-7",
        #...
    ],
    "allowed_push_targets": [],
    "short": "rhel"
}
> pdc_client -r products/rhel -x PATCH -d '{"allowed_push_targets":["rhn-live","rhn-stage"]}'
{
    "active": true,
    "name": "Red Hat Enterprise Linux",
    "product_versions": [
        "rhel-7",
        #...
    ],
    "allowed_push_targets": [
        "rhn-live",
        "rhn-stage"
    ],
    "short": "rhel"
}
> pdc_client -r product-versions/rhel-7
{
    "active": true,
    "name": "Red Hat Enterprise Linux",
    "product": "rhel",
    "product_version_id": "rhel-7",
    "allowed_push_targets": [
        "rhn-live",
        "rhn-stage"
    ],
    "releases": [
        "rhel-7.0",
        "rhel-7.1"
    ],
    "short": "rhel",
    "version": "7"
}
> pdc_client -r releases/rhel-7.0
{
    #...
    "allowed_push_targets": [
        "rhn-live",
        "rhn-stage"
    ],
    "release_id": "rhel-7.0",
    #...
}
> pdc_client -r releases/rhel-7.1
{
    #...
    "allowed_push_targets": [
        "rhn-live",
        "rhn-stage"
    ],
    "release_id": "rhel-7.1",
    #...
}
> pdc_client -r release-variants -d '{"release":"rhel-7.1"}'
{
    "count": 12,
    "next": null,
    "previous": null,
    "results": [
        # ...
        {
            "id": "Workstation",
            "name": "Workstation",
            "allowed_push_targets": [
                "rhn-live",
                "rhn-stage"
            ],
            "release": "rhel-7.1",
            #...
        }
    ]
}
> pdc_client -r product-versions/rhel-7 -x PATCH -d '{"allowed_push_targets":[]}'
{
    #...
    "allowed_push_targets": [],
    #...
}
> pdc_client -r releases/rhel-7.1
{
    #...
    "allowed_push_targets": [],
    #...
}

# bad: rhn-live is not in rhel-7
> pdc_client -r releases/rhel-7.1 -x PATCH -d '{"allowed_push_targets":["rhn-live"]}'
400 {"detail":["Invalid push targets: [u'rhn-live']"]}
```