### PR TITLE
Use persistent test DB (--keepdb can skip migrations)

### DIFF
--- a/pdc/settings_test.py
+++ b/pdc/settings_test.py
@@ -15,10 +15,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': 'test.sqlite3',
-        'USER': '',
-        'PASSWORD': '',
-        'HOST': '',
-        'PORT': '',
+        'TEST': {'NAME': 'test.sqlite3'},
     }
 }
 


### PR DESCRIPTION
By default test database is in-memory (':memory:'), i.e. not saved on
disk, making it impossible to skip migrations to quickly re-run tests
with '--keepdb' argument.