### PR TITLE
Filter multi-destinations by repo release_id

### DIFF
--- a/pdc/apps/repository/filters.py
+++ b/pdc/apps/repository/filters.py
@@ -50,6 +50,8 @@ class MultiDestinationFilter(filters.FilterSet):
     global_component = MultiValueFilter(name='global_component__name')
     origin_repo = MultiValueFilter()
     destination_repo = MultiValueFilter()
+    origin_repo_release_id = MultiValueFilter(name='origin_repo__variant_arch__variant__release__release_id')
+    destination_repo_release_id = MultiValueFilter(name='destination_repo__variant_arch__variant__release__release_id')
     subscribers = MultiValueFilter(name='subscribers__name')
     active = CaseInsensitiveBooleanFilter()
 
@@ -60,6 +62,8 @@ class MultiDestinationFilter(filters.FilterSet):
             'global_component',
             'origin_repo',
             'destination_repo',
+            'origin_repo_release_id',
+            'destination_repo_release_id',
             'subscribers',
             'active',
         )

--- a/pdc/apps/repository/tests.py
+++ b/pdc/apps/repository/tests.py
@@ -857,6 +857,18 @@ class MultiDestinationRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('count'), 0)
 
+    def test_filter_by_release_id(self):
+        for repo in ['origin_repo', 'destination_repo']:
+            response = self.client.get(reverse('multidestination-list'), {repo + '_release_id': 'release-1.0'})
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data.get('count'), 1)
+            result = response.data.get('results')[0]
+            self.assertEqual(result[repo]['release_id'], 'release-1.0')
+
+            response = self.client.get(reverse('multidestination-list'), {repo + '_release_id': 'release-2.0'})
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data.get('count'), 0)
+
     def test_add(self):
         data = {
             'global_component': 'python',


### PR DESCRIPTION
Adds filter fields `origin_repo_release_id` and
`destination_repo_release_id`.

JIRA: PDC-1970

---
I forgot to add filtering (mentioned in JIRA) in previous PR.