### PR TITLE
Various fixes for the unreleasedvariants API

### DIFF
--- a/pdc/apps/module/tests.py
+++ b/pdc/apps/module/tests.py
@@ -141,6 +141,21 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertNumChanges([2])
         self.assertIn('new_rpm', response.content)
 
+    def test_create_and_delete_unreleasedvariant(self):
+        url = reverse('unreleasedvariant-list')
+        data = {
+            'variant_id': 'core', 'variant_uid': 'core-test-123',
+            'variant_name': 'core', 'variant_version': '0',
+            'variant_release': '1', 'variant_type': 'module',
+            'koji_tag': 'module-core-0-1', 'modulemd': 'foobar',
+            'active': False
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        url_two = reverse('unreleasedvariant-detail', args=['core-test-123'])
+        response_two = self.client.delete(url_two)
+        self.assertEqual(response_two.status_code, status.HTTP_204_NO_CONTENT)
+
     def test_filter_by_rpms(self):
         url = reverse('unreleasedvariant-list')
         # add a variant with rpm 'foobar' from branch 'master'

--- a/pdc/apps/module/views.py
+++ b/pdc/apps/module/views.py
@@ -29,7 +29,6 @@ class UnreleasedVariantViewSet(viewsets.PDCModelViewSet):
     serializer_class = UnreleasedVariantSerializer
     filter_class = UnreleasedVariantFilter
     lookup_field = 'variant_uid'
-    lookup_regex = '[^/]+'
 
     def list(self, request, *args, **kwargs):
         """

--- a/pdc/apps/module/views.py
+++ b/pdc/apps/module/views.py
@@ -74,7 +74,7 @@ class UnreleasedVariantViewSet(viewsets.PDCModelViewSet):
         __Method__:
         GET
 
-        __URL__: $LINK:unreleasedvariant-detail:variant_id$
+        __URL__: $LINK:unreleasedvariant-detail:variant_uid$
 
         __Response__:
 
@@ -162,7 +162,7 @@ class UnreleasedVariantViewSet(viewsets.PDCModelViewSet):
         __Method__:
         DELETE
 
-        __URL__: $LINK:unreleasedvariant-detail:variant_id$
+        __URL__: $LINK:unreleasedvariant-detail:variant_uid$
 
         __Response__:
 


### PR DESCRIPTION
This PR:
* Adds a delete test for the unreleasedvariants API
* Remove unused 'lookup_regex' variable. The original author must have meant to use 'lookup_value_regex'
* Fixes the URL format in the unreleasedvariants documentation