### PR TITLE
Remove "trailing slash" hint from errors

### DIFF
--- a/pdc/settings_common.py
+++ b/pdc/settings_common.py
@@ -292,9 +292,6 @@ BROWSABLE_DOCUMENT_MACROS = {
 
 EMPTY_PATCH_ERROR_RESPONSE = {
     'detail': 'Partial update with no changes does not make much sense.',
-    'hint': ' '.join(['Please make sure the URL includes the trailing slash.',
-                      'Some software may automatically redirect you the the',
-                      'correct URL but not forward the request body.'])
 }
 
 INTERNAL_SERVER_ERROR_RESPONSE = {


### PR DESCRIPTION
Removes "make sure URL includes trailing slash" from unrelated update
errors (empty request data).

JIRA: PDC-2298