### PR TITLE
Bump uglify-js version in example

### DIFF
--- a/examples/contact-browser/package.json
+++ b/examples/contact-browser/package.json
@@ -17,7 +17,7 @@
     "react-tools": ">=0.13.3",
     "browserify": "~10.2.4",
     "reactify": "~1.1.1",
-    "uglify-js": "~2.4.23",
+    "uglify-js": "~>2.6.0",
     "resource-embedder": "~0.2.2"
   }
 }


### PR DESCRIPTION
There is CVE-2015-8858 for uglify-js versions below 2.6.0.

This was detected and suggested by github [1].

[1] https://help.github.com/articles/about-security-alerts-for-vulnerable-dependencies/