### PR TITLE
Fix long SQL query for releases

### DIFF
--- a/pdc/apps/release/views.py
+++ b/pdc/apps/release/views.py
@@ -333,7 +333,7 @@ class ReleaseViewSet(ChangeSetCreateModelMixin,
     """
     queryset = models.Release.objects \
                      .select_related('product_version', 'release_type', 'base_product') \
-                     .prefetch_related('compose_set').order_by('id')
+                     .order_by('id')
     serializer_class = ReleaseSerializer
     lookup_field = 'release_id'
     lookup_value_regex = '[^/]+'


### PR DESCRIPTION
Listing releases with lots of related composes caused SQL query for
prefetching to have too many parameters.

The prefetch query looks like this:

    SELECT "compose_compose"."id", "compose_compose"."release_id", ...
    FROM "compose_compose"
    WHERE "compose_compose"."release_id" IN (1, 2, /* ... too many IDs */)

JIRA: PDC-1733

---

Haven't seen any performance regression but I tested this only with ~170 related composes.