### PR TITLE
Add the "variant_context" field to the unreleasedvariants API

### DIFF
--- a/pdc/apps/module/filters.py
+++ b/pdc/apps/module/filters.py
@@ -17,6 +17,7 @@ class UnreleasedVariantFilter(django_filters.FilterSet):
     variant_type        = django_filters.CharFilter(name='variant_type', lookup_type='iexact')
     variant_version     = django_filters.CharFilter(name='variant_version', lookup_type='iexact')
     variant_release     = django_filters.CharFilter(name='variant_release', lookup_type='iexact')
+    variant_context     = django_filters.CharFilter(name='variant_context', lookup_type='iexact')
     active              = CaseInsensitiveBooleanFilter()
     koji_tag            = django_filters.CharFilter(name='koji_tag', lookup_type='iexact')
     runtime_dep_name    = MultiValueFilter(name='runtime_deps__dependency', distinct=True)
@@ -29,7 +30,7 @@ class UnreleasedVariantFilter(django_filters.FilterSet):
     class Meta:
         model = UnreleasedVariant
         fields = ('variant_id', 'variant_uid', 'variant_name', 'variant_type',
-                  'variant_version', 'variant_release', 'koji_tag',
+                  'variant_version', 'variant_release', 'variant_context', 'koji_tag',
                   'modulemd', 'runtime_dep_name', 'runtime_dep_stream',
                   'build_dep_name', 'build_dep_stream', 'component_name',
                   'component_branch')

--- a/pdc/apps/module/migrations/0007_unreleasedvariant_context_field.py
+++ b/pdc/apps/module/migrations/0007_unreleasedvariant_context_field.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('module', '0006_unreleasedvariant_rpms'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='unreleasedvariant',
+            name='variant_context',
+            field=models.CharField(default=b'00000000', max_length=100),
+        ),
+        migrations.AlterModelOptions(
+            name='unreleasedvariant',
+            options={'ordering': ('variant_name', 'variant_version', 'variant_release', 'variant_context')},
+        ),
+        migrations.AlterUniqueTogether(
+            name='unreleasedvariant',
+            unique_together=set([('variant_name', 'variant_version', 'variant_release', 'variant_context')]),
+        ),
+    ]

--- a/pdc/apps/module/migrations/0008_unreleasedvariant_make_variant_uid_unique.py
+++ b/pdc/apps/module/migrations/0008_unreleasedvariant_make_variant_uid_unique.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('module', '0007_unreleasedvariant_context_field'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='unreleasedvariant',
+            name='variant_uid',
+            field=models.CharField(unique=True, max_length=200),
+        )
+    ]

--- a/pdc/apps/module/models.py
+++ b/pdc/apps/module/models.py
@@ -9,7 +9,7 @@ from pdc.apps.package.models import RPM
 class UnreleasedVariant(models.Model):
     # Not the variant from compose ... which back references compose
     variant_id          = models.CharField(max_length=100, blank=False)
-    variant_uid         = models.CharField(max_length=200, blank=False)
+    variant_uid         = models.CharField(max_length=200, blank=False, unique=True)
     variant_name        = models.CharField(max_length=300, blank=False)
     variant_type        = models.CharField(max_length=100, blank=False)
     # variant_version/_release are _not_ distribution versions/releases

--- a/pdc/apps/module/models.py
+++ b/pdc/apps/module/models.py
@@ -15,15 +15,21 @@ class UnreleasedVariant(models.Model):
     # variant_version/_release are _not_ distribution versions/releases
     variant_version     = models.CharField(max_length=100, blank=False)
     variant_release     = models.CharField(max_length=100, blank=False)
+    # Default to '00000000' for now since this field will only be used once
+    # other tooling is updated to supply this value. Eventually, this should
+    # not have a default.
+    variant_context     = models.CharField(max_length=100, blank=False, default='00000000')
     active              = models.BooleanField(default=False)
     koji_tag            = models.CharField(max_length=300, blank=False)
     modulemd            = models.TextField(blank=False)
     rpms                = models.ManyToManyField(RPM)
 
     class Meta:
-        ordering = ("variant_uid", "variant_version", "variant_release")
+        ordering = ("variant_name", "variant_version", "variant_release",
+                    "variant_context")
         unique_together = (
-            ("variant_uid", "variant_version", "variant_release"),
+            ("variant_name", "variant_version", "variant_release",
+             "variant_context"),
         )
 
     def __unicode__(self):
@@ -37,6 +43,7 @@ class UnreleasedVariant(models.Model):
             'variant_type': self.variant_type,
             'variant_version': self.variant_version,
             'variant_release': self.variant_release,
+            'variant_context': self.variant_context,
             'active': self.active,
             'koji_tag': self.koji_tag,
             'modulemd': self.modulemd,

--- a/pdc/apps/module/serializers.py
+++ b/pdc/apps/module/serializers.py
@@ -12,30 +12,6 @@ from pdc.apps.package.serializers import RPMRelatedField
 from pdc.apps.package.models import RPM
 
 
-class UnreleasedVariantField(serializers.Field):
-
-    def to_internal_value(self, data):
-        try:
-            variant = UnreleasedVariant.objects.get(
-                variant_uid=data['variant_uid'],
-                variant_version=data['variant_version'],
-                variant_release=data['variant_release'])
-        except UnreleasedVariant.DoesNotExist:
-            raise serializers.ValidationError("UnreleasedVariant %s does not exist.")
-        return variant
-
-    def to_representation(self, value):
-        return {'variant_uid': value.variant_uid, 'variant_name': value.variant_name}
-
-
-class JSONSerializerField(serializers.Field):
-    def to_internal_value(self, data):
-        return data
-
-    def to_representation(self, value):
-        return value
-
-
 class RuntimeDepSerializer(serializers.ModelSerializer):
     class Meta:
         model = RuntimeDependency

--- a/pdc/apps/module/serializers.py
+++ b/pdc/apps/module/serializers.py
@@ -32,6 +32,10 @@ class UnreleasedVariantSerializer(StrictSerializerMixin,
     variant_type        = serializers.CharField(max_length=100)
     variant_version     = serializers.CharField(max_length=100)
     variant_release     = serializers.CharField(max_length=100)
+    # Default to '00000000' for now since this field will only be used once
+    # other tooling is updated to supply this value. Eventually, this should
+    # not have a default.
+    variant_context     = serializers.CharField(max_length=100, default='00000000')
     active              = serializers.BooleanField(default=False)
     koji_tag            = serializers.CharField(max_length=300)
     modulemd            = serializers.CharField()
@@ -45,8 +49,9 @@ class UnreleasedVariantSerializer(StrictSerializerMixin,
         model = UnreleasedVariant
         fields = (
             'variant_id', 'variant_uid', 'variant_name', 'variant_type',
-            'variant_version', 'variant_release', 'koji_tag', 'modulemd',
-            'runtime_deps', 'build_deps', 'active', 'rpms',
+            'variant_version', 'variant_release', 'variant_context',
+            'koji_tag', 'modulemd', 'runtime_deps', 'build_deps', 'active',
+            'rpms',
         )
 
     def validate(self, attrs):

--- a/pdc/apps/module/tests.py
+++ b/pdc/apps/module/tests.py
@@ -25,7 +25,8 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
             'variant_id': "core", 'variant_uid': "Core",
             'variant_name': "Core", 'variant_version': "0",
             'variant_release': "1", 'variant_type': 'module',
-            'koji_tag': "module-core-0-1", 'modulemd': 'foobar'
+            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
+            'modulemd': 'foobar'
         }
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -36,7 +37,8 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
             'variant_id': "shells", 'variant_uid': "Shells",
             'variant_name': "Shells", 'variant_version': "0",
             'variant_release': "1", 'variant_type': 'module',
-            'koji_tag': "module-shells-0-1", 'modulemd': 'foobar'}
+            'variant_context': '12345678', 'koji_tag': "module-shells-0-1",
+            'modulemd': 'foobar'}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -46,18 +48,18 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
             'variant_id': "core", 'variant_uid': "Core",
             'variant_name': "Core", 'variant_version': "0",
             'variant_release': "1", 'variant_type': 'module',
-            'koji_tag': "module-core-0-1", 'modulemd': 'foobar',
-            'active': False,
+            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
+            'modulemd': 'foobar', 'active': False,
         }
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         data = {
-            'variant_id': "core", 'variant_uid': "Core",
+            'variant_id': "core", 'variant_uid': "Core2",
             'variant_name': "Core", 'variant_version': "0",
             'variant_release': "2", 'variant_type': 'module',
-            'koji_tag': "module-core-0-2", 'modulemd': 'foobar',
-            'active': True,
+            'variant_context': '12345678', 'koji_tag': "module-core-0-2",
+            'modulemd': 'foobar', 'active': True,
         }
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -77,8 +79,9 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
             'variant_id': "core", 'variant_uid': "Core",
             'variant_name': "Core", 'variant_version': "0",
             'variant_release': "1", 'variant_type': 'module',
-            'koji_tag': "module-core-0-1", 'modulemd': 'foobar',
-            'build_deps': [{'dependency': 'base-runtime', 'stream': 'master'}]
+            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
+            'modulemd': 'foobar', 'build_deps': [
+                {'dependency': 'base-runtime', 'stream': 'master'}]
         }
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -88,8 +91,9 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
             'variant_id': "core3", 'variant_uid': "Core3",
             'variant_name': "Core3", 'variant_version': "0",
             'variant_release': "1", 'variant_type': 'module',
-            'koji_tag': "module-core3-0-1", 'modulemd': 'foobar',
-            'build_deps': [{'dependency': 'base-runtime', 'stream': 'f26'}]
+            'variant_context': '12345678', 'koji_tag': "module-core3-0-1",
+            'modulemd': 'foobar', 'build_deps': [
+                {'dependency': 'base-runtime', 'stream': 'f26'}]
         }
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -99,8 +103,9 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
             'variant_id': "core2", 'variant_uid': "Core2",
             'variant_name': "Core2", 'variant_version': "0",
             'variant_release': "1", 'variant_type': 'module',
-            'koji_tag': "module-core2-0-1", 'modulemd': 'foobar',
-            'build_deps': [{'dependency': 'bootstrap', 'stream': 'master'}]
+            'variant_context': '12345678', 'koji_tag': "module-core2-0-1",
+            'modulemd': 'foobar', 'build_deps': [
+                {'dependency': 'bootstrap', 'stream': 'master'}]
         }
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -132,8 +137,8 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
             'variant_id': "core", 'variant_uid': "Core",
             'variant_name': "Core", 'variant_version': "0",
             'variant_release': "1", 'variant_type': 'module',
-            'koji_tag': "module-core-0-1", 'modulemd': 'foobar',
-            'active': False,
+            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
+            'modulemd': 'foobar', 'active': False,
             'rpms': [{'name': 'new_rpm', 'epoch': 0, 'version': '1.0.0',
                         'release': '1', 'arch': 'src', 'srpm_name': 'new_srpm'}]
         }
@@ -148,8 +153,8 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
             'variant_id': 'core', 'variant_uid': 'core-test-123',
             'variant_name': 'core', 'variant_version': '0',
             'variant_release': '1', 'variant_type': 'module',
-            'koji_tag': 'module-core-0-1', 'modulemd': 'foobar',
-            'active': False
+            'variant_context': '12345678', 'koji_tag': 'module-core-0-1',
+            'modulemd': 'foobar', 'active': False
         }
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -164,8 +169,8 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
             'variant_id': "core", 'variant_uid': "Core",
             'variant_name': "Core", 'variant_version': "0",
             'variant_release': "1", 'variant_type': 'module',
-            'koji_tag': "module-core-0-1", 'modulemd': 'foobar',
-            'active': True,
+            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
+            'modulemd': 'foobar', 'active': True,
             'rpms': [{'name': 'foobar', 'epoch': 0, 'version': '1.0.0',
                       'release': '1', 'arch': 'src', 'srpm_name': 'foobar',
                       'srpm_commit_branch': 'master'}]
@@ -179,8 +184,8 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
             'variant_id': "core2", 'variant_uid': "Core2",
             'variant_name': "Core2", 'variant_version': "0",
             'variant_release': "1", 'variant_type': 'module',
-            'koji_tag': "module-core2-0-1", 'modulemd': 'foobar',
-            'active': True,
+            'variant_context': '12345678', 'koji_tag': "module-core2-0-1",
+            'modulemd': 'foobar', 'active': True,
             'rpms': [{'name': 'foobar', 'epoch': 0, 'version': '2.0.0',
                       'release': '1', 'arch': 'src', 'srpm_name': 'foobar',
                       'srpm_commit_branch': 'rawhide'}]
@@ -218,8 +223,8 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
             'variant_id': "core", 'variant_uid': "Core",
             'variant_name': "Core", 'variant_version': "0",
             'variant_release': "1", 'variant_type': 'module',
-            'koji_tag': "module-core-0-1", 'modulemd': 'foobar',
-            'active': False,
+            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
+            'modulemd': 'foobar', 'active': False,
             'rpms': [{
                 "name": "bash-doc",
                 "epoch": 0,
@@ -252,8 +257,8 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
             'variant_id': "core", 'variant_uid': "coretest123",
             'variant_name': "core", 'variant_version': "0",
             'variant_release': "1", 'variant_type': 'module',
-            'koji_tag': "module-core-0-1", 'modulemd': 'foobar',
-            'active': False
+            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
+            'modulemd': 'foobar', 'active': False
         }
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -264,3 +269,32 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
         uv = UnreleasedVariant.objects.filter(
             variant_uid='coretest123').first()
         self.assertTrue(uv.active)
+
+    def test_create_unreleasedvariant_default_context(self):
+        url = reverse('unreleasedvariant-list')
+        data = {
+            'variant_id': "core", 'variant_uid': "coretest123",
+            'variant_name': "Core", 'variant_version': "0",
+            'variant_release': "1", 'variant_type': 'module',
+            'koji_tag': "module-core-0-1", 'modulemd': 'foobar'
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        uv = UnreleasedVariant.objects.filter(
+            variant_uid='coretest123').first()
+        self.assertEqual(uv.variant_context, '00000000')
+
+    def test_create_unreleasedvariant_not_default_context(self):
+        url = reverse('unreleasedvariant-list')
+        data = {
+            'variant_id': "core", 'variant_uid': "coretest123",
+            'variant_name': "Core", 'variant_version': "0",
+            'variant_release': "1", 'variant_type': 'module',
+            'variant_context': 'a23d56a8', 'koji_tag': "module-core-0-1",
+            'modulemd': 'foobar'
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        uv = UnreleasedVariant.objects.filter(
+            variant_uid='coretest123').first()
+        self.assertEqual(uv.variant_context, 'a23d56a8')

--- a/pdc/apps/module/views.py
+++ b/pdc/apps/module/views.py
@@ -56,6 +56,7 @@ class UnreleasedVariantViewSet(viewsets.PDCModelViewSet):
                         "variant_type": string,
                         "variant_version": string,
                         "variant_release": string,
+                        "variant_context": string,
                         "koji_tag": string,
                         "modulemd": string,
                         "active": bool,
@@ -85,6 +86,7 @@ class UnreleasedVariantViewSet(viewsets.PDCModelViewSet):
                 "variant_type": string,
                 "variant_version": string,
                 "variant_release": string,
+                "variant_context": string,
                 "koji_tag": string,
                 "modulemd": string,
                 "active": bool,
@@ -111,6 +113,7 @@ class UnreleasedVariantViewSet(viewsets.PDCModelViewSet):
                 "variant_type": string,   # required
                 "variant_version": string,# version of this particular variant
                 "variant_release": string,# release of this particular variant
+                "variant_context": string,
                 "koji_tag": string,       # required
                 "modulemd": string,       # required
                 "active": bool,           # required
@@ -128,6 +131,7 @@ class UnreleasedVariantViewSet(viewsets.PDCModelViewSet):
                 "variant_type": string,
                 "variant_version": string,
                 "variant_release": string,
+                "variant_context": string,
                 "koji_tag": string,
                 "modulemd": string,
                 "active": bool,
@@ -139,7 +143,7 @@ class UnreleasedVariantViewSet(viewsets.PDCModelViewSet):
         __Example__:
 
             curl -X POST -H "Content-Type: application/json" $URL:unreleasedvariant-list$ \\
-                    -d '{ "variant_id": "core", "variant_uid": "Core", "variant_name": "Minimalistic Core", "variant_type": "module", "variant_version": "master", "variant_release": "20170101", "koji_tag": "foobar", "active": false }'
+                    -d '{ "variant_id": "core", "variant_uid": "Core", "variant_name": "Minimalistic Core", "variant_type": "module", "variant_version": "master", "variant_release": "20170101", "variant_context": "2f345c78", "koji_tag": "foobar", "active": false }'
             # output
             {
                 "variant_id": "core",
@@ -148,6 +152,7 @@ class UnreleasedVariantViewSet(viewsets.PDCModelViewSet):
                 "variant_type": "module",
                 "variant_version": "master",
                 "variant_release": "20170101",
+                "variant_context": string,
                 "koji_tag": "foobar",
                 "active": false,
                 "runtime_deps": [],
@@ -190,6 +195,7 @@ class UnreleasedVariantViewSet(viewsets.PDCModelViewSet):
                 "variant_type": string,   # required
                 "variant_version": string,# version of this particular variant
                 "variant_release": string,# release of this particular variant
+                "variant_context": string,# context of this particular variant
                 "koji_tag": string,       # required
                 "modulemd": string,       # required
                 "active": bool,           # required
@@ -207,6 +213,7 @@ class UnreleasedVariantViewSet(viewsets.PDCModelViewSet):
                 "variant_type": string,
                 "variant_version": string,
                 "variant_release": string,
+                "variant_context": string,
                 "koji_tag": string,
                 "modulemd": string,
                 "active": bool,


### PR DESCRIPTION
This PR adds the "variant_context" field to the unreleasedvariants API. This field is used to identify a module build with the same name (variant_name), stream (variant_version), and version (variant_release).

This PR also fixes a bug where uniqueness is not enforced on the "variant_uid" field.