### PR TITLE
Container build throws 404 error on graphviz repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ LABEL Version = "0.5"
 
 # patternfly1
 RUN curl -L https://copr.fedorainfracloud.org/coprs/patternfly/patternfly1/repo/fedora-26/patternfly-patternfly1-fedora-26.repo > /etc/yum.repos.d/patternfly-patternfly1-fedora-26.repo
-RUN curl -L http://www.graphviz.org/graphviz-rhel.repo > /etc/yum.repos.d/graphviz-rhel.repo
 
 # solve dependencies
 RUN dnf -y upgrade && \


### PR DESCRIPTION
- external graphviz repository URL is no longer valid
- drop the dependency on the external graphviz repository since
  a previous commit changed the container to use Fedora which
  provides a suitable version of graphviz

Signed-off-by: Robert Marshall <rmarshall@redhat.com>