### PR TITLE
Add v2 of the "unreleasedvariants" API called "module"

### DIFF
--- a/pdc/apps/module/__init__.py
+++ b/pdc/apps/module/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015 Red Hat
+# Copyright (c) 2018 Red Hat
 # Licensed under The MIT License (MIT)
 # http://opensource.org/licenses/MIT
 #

--- a/pdc/apps/module/admin.py
+++ b/pdc/apps/module/admin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015 Red Hat
+# Copyright (c) 2018 Red Hat
 # Licensed under The MIT License (MIT)
 # http://opensource.org/licenses/MIT
 #

--- a/pdc/apps/module/apps.py
+++ b/pdc/apps/module/apps.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015 Red Hat
+# Copyright (c) 2018 Red Hat
 # Licensed under The MIT License (MIT)
 # http://opensource.org/licenses/MIT
 #

--- a/pdc/apps/module/filters.py
+++ b/pdc/apps/module/filters.py
@@ -7,17 +7,10 @@
 import django_filters
 
 from pdc.apps.common.filters import CaseInsensitiveBooleanFilter, MultiValueFilter
-from .models import UnreleasedVariant
+from pdc.apps.module.models import Module
 
 
-class UnreleasedVariantFilter(django_filters.FilterSet):
-    variant_id          = django_filters.CharFilter(name='variant_id', lookup_type='iexact')
-    variant_uid         = django_filters.CharFilter(name='variant_uid', lookup_type='iexact')
-    variant_name        = django_filters.CharFilter(name='variant_name', lookup_type='iexact')
-    variant_type        = django_filters.CharFilter(name='variant_type', lookup_type='iexact')
-    variant_version     = django_filters.CharFilter(name='variant_version', lookup_type='iexact')
-    variant_release     = django_filters.CharFilter(name='variant_release', lookup_type='iexact')
-    variant_context     = django_filters.CharFilter(name='variant_context', lookup_type='iexact')
+class ModuleFilterBase(django_filters.FilterSet):
     active              = CaseInsensitiveBooleanFilter()
     koji_tag            = django_filters.CharFilter(name='koji_tag', lookup_type='iexact')
     runtime_dep_name    = MultiValueFilter(name='runtime_deps__dependency', distinct=True)
@@ -27,10 +20,16 @@ class UnreleasedVariantFilter(django_filters.FilterSet):
     component_name      = MultiValueFilter(name='rpms__srpm_name', distinct=True)
     component_branch    = MultiValueFilter(name='rpms__srpm_commit_branch', distinct=True)
 
+
+class ModuleFilter(ModuleFilterBase):
+    uid                 = django_filters.CharFilter(name='uid', lookup_type='iexact')
+    name                = django_filters.CharFilter(name='name', lookup_type='iexact')
+    stream              = django_filters.CharFilter(name='stream', lookup_type='iexact')
+    version             = django_filters.CharFilter(name='version', lookup_type='iexact')
+    context             = django_filters.CharFilter(name='context', lookup_type='iexact')
+
     class Meta:
-        model = UnreleasedVariant
-        fields = ('variant_id', 'variant_uid', 'variant_name', 'variant_type',
-                  'variant_version', 'variant_release', 'variant_context', 'koji_tag',
-                  'modulemd', 'runtime_dep_name', 'runtime_dep_stream',
-                  'build_dep_name', 'build_dep_stream', 'component_name',
-                  'component_branch')
+        model = Module
+        fields = ('uid', 'name', 'stream', 'version', 'context', 'active', 'koji_tag',
+                  'runtime_dep_name', 'runtime_dep_stream', 'build_dep_name', 'build_dep_stream',
+                  'component_name', 'component_branch')

--- a/pdc/apps/module/filters.py
+++ b/pdc/apps/module/filters.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015 Red Hat
+# Copyright (c) 2018 Red Hat
 # Licensed under The MIT License (MIT)
 # http://opensource.org/licenses/MIT
 #

--- a/pdc/apps/module/migrations/0009_v2.py
+++ b/pdc/apps/module/migrations/0009_v2.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('module', '0008_unreleasedvariant_make_variant_uid_unique'),
+    ]
+
+    operations = [
+        migrations.RenameModel('UnreleasedVariant', 'Module'),
+        migrations.RenameField(
+            model_name='module',
+            old_name='variant_version',
+            new_name='stream',
+        ),
+        migrations.RenameField(
+            model_name='module',
+            old_name='variant_release',
+            new_name='version',
+        ),
+        migrations.RenameField(
+            model_name='module',
+            old_name='variant_context',
+            new_name='context',
+        ),
+        migrations.RenameField(
+            model_name='module',
+            old_name='variant_name',
+            new_name='name',
+        ),
+        migrations.RenameField(
+            model_name='module',
+            old_name='variant_type',
+            new_name='type',
+        ),
+        migrations.RenameField(
+            model_name='module',
+            old_name='variant_uid',
+            new_name='uid',
+        ),
+        # Increase the max length to be the sum of name:stream:version:context
+        # with a little bit of cushion
+        migrations.AlterField(
+            model_name='module',
+            name='uid',
+            field=models.CharField(unique=True, max_length=610),
+        ),
+        # Set the default value to 'module'
+        migrations.AlterField(
+            model_name='module',
+            name='type',
+            field=models.CharField(default=b'module', max_length=100),
+        ),
+        # Remove the default value
+        migrations.AlterField(
+            model_name='module',
+            name='context',
+            field=models.CharField(max_length=100),
+        ),
+        migrations.AlterModelOptions(
+            name='module',
+            options={'ordering': ('name', 'stream', 'version', 'context')},
+        ),
+        migrations.AlterUniqueTogether(
+            name='module',
+            unique_together=set([('name', 'stream', 'version', 'context')]),
+        ),
+    ]

--- a/pdc/apps/module/models.py
+++ b/pdc/apps/module/models.py
@@ -6,61 +6,49 @@ from django.db import models
 from pdc.apps.package.models import RPM
 
 
-class UnreleasedVariant(models.Model):
-    # Not the variant from compose ... which back references compose
-    variant_id          = models.CharField(max_length=100, blank=False)
-    variant_uid         = models.CharField(max_length=200, blank=False, unique=True)
-    variant_name        = models.CharField(max_length=300, blank=False)
-    variant_type        = models.CharField(max_length=100, blank=False)
-    # variant_version/_release are _not_ distribution versions/releases
-    variant_version     = models.CharField(max_length=100, blank=False)
-    variant_release     = models.CharField(max_length=100, blank=False)
-    # Default to '00000000' for now since this field will only be used once
-    # other tooling is updated to supply this value. Eventually, this should
-    # not have a default.
-    variant_context     = models.CharField(max_length=100, blank=False, default='00000000')
-    active              = models.BooleanField(default=False)
-    koji_tag            = models.CharField(max_length=300, blank=False)
-    modulemd            = models.TextField(blank=False)
-    rpms                = models.ManyToManyField(RPM)
+class Module(models.Model):
+    variant_id  = models.CharField(max_length=100, blank=False)
+    uid         = models.CharField(max_length=610, blank=False, unique=True)
+    name        = models.CharField(max_length=300, blank=False)
+    stream      = models.CharField(max_length=100, blank=False)
+    version     = models.CharField(max_length=100, blank=False)
+    context     = models.CharField(max_length=100, blank=False)
+    # No new instances should have a `type` value other than `module`. This is here just for
+    # backwards compatibility with the `unreleasedvariants` API.
+    type        = models.CharField(max_length=100, blank=False, default='module')
+    active      = models.BooleanField(default=False)
+    koji_tag    = models.CharField(max_length=300, blank=False)
+    modulemd    = models.TextField(blank=False)
+    rpms        = models.ManyToManyField(RPM)
 
     class Meta:
-        ordering = ("variant_name", "variant_version", "variant_release",
-                    "variant_context")
+        ordering = ('name', 'stream', 'version', 'context')
         unique_together = (
-            ("variant_name", "variant_version", "variant_release",
-             "variant_context"),
+            ('name', 'stream', 'version', 'context'),
         )
 
     def __unicode__(self):
-        return u"%s" % (self.variant_uid, )
+        return u'%s' % (self.uid, )
 
     def export(self):
-        result = {
+        return {
             'variant_id': self.variant_id,
-            'variant_uid': self.variant_uid,
-            'variant_name': self.variant_name,
-            'variant_type': self.variant_type,
-            'variant_version': self.variant_version,
-            'variant_release': self.variant_release,
-            'variant_context': self.variant_context,
+            'uid': self.uid,
+            'name': self.name,
+            'stream': self.stream,
+            'version': self.version,
+            'context': self.context,
+            'type': self.type,
             'active': self.active,
             'koji_tag': self.koji_tag,
             'modulemd': self.modulemd,
+            'rpms': [obj.export() for obj in self.rpms.all()],
             'runtime_deps': [v.dependency for v in self.runtime_deps.all()],
             'build_deps': [v.dependency for v in self.build_deps.all()],
         }
 
-        result["rpms"] = []
-        objects = self.rpms.all()
-        for obj in objects:
-            result["rpms"].append(obj.export())
 
-        return result
-
-
-class VariantDependency(models.Model):
-
+class ModuleDependency(models.Model):
     dependency = models.CharField(max_length=300)
     stream = models.CharField(max_length=300)
 
@@ -68,13 +56,9 @@ class VariantDependency(models.Model):
         abstract = True
 
 
-class RuntimeDependency(VariantDependency):
-
-    variant = models.ForeignKey("UnreleasedVariant",
-                                related_name="runtime_deps")
+class RuntimeDependency(ModuleDependency):
+    variant = models.ForeignKey('Module', related_name='runtime_deps')
 
 
-class BuildDependency(VariantDependency):
-
-    variant = models.ForeignKey("UnreleasedVariant",
-                                related_name="build_deps")
+class BuildDependency(ModuleDependency):
+    variant = models.ForeignKey('Module', related_name='build_deps')

--- a/pdc/apps/module/models.py
+++ b/pdc/apps/module/models.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015 Red Hat
+# Copyright (c) 2018 Red Hat
 # Licensed under The MIT License (MIT)
 # http://opensource.org/licenses/MIT
 from django.db import models

--- a/pdc/apps/module/routers.py
+++ b/pdc/apps/module/routers.py
@@ -1,5 +1,5 @@
-from . import views
+from pdc.apps.module.views import ModuleViewSet
 from pdc.apps.utils.SortedRouter import router
 
 
-router.register(r'unreleasedvariants', views.UnreleasedVariantViewSet)
+router.register(r'modules', ModuleViewSet, base_name='modules')

--- a/pdc/apps/module/routers.py
+++ b/pdc/apps/module/routers.py
@@ -1,3 +1,8 @@
+#
+# Copyright (c) 2018 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#
 from pdc.apps.module.views import ModuleViewSet
 from pdc.apps.utils.SortedRouter import router
 

--- a/pdc/apps/module/serializers.py
+++ b/pdc/apps/module/serializers.py
@@ -6,72 +6,72 @@
 from rest_framework import serializers
 
 from pdc.apps.common.serializers import StrictSerializerMixin
-from .models import UnreleasedVariant, RuntimeDependency, BuildDependency
-
+from pdc.apps.module.models import Module, RuntimeDependency, BuildDependency
 from pdc.apps.package.serializers import RPMRelatedField
 from pdc.apps.package.models import RPM
+
+
+# Inherit from this class so we can override the documentation variables
+class RPMModuleField(RPMRelatedField):
+    doc_format = '"string"'
+    writable_doc_format = ('{"name": "string", "epoch": "string", "version": "string", '
+                           '"release": "string", "arch": "string", "srpm_name": "string"}')
 
 
 class RuntimeDepSerializer(serializers.ModelSerializer):
     class Meta:
         model = RuntimeDependency
-        fields = ("dependency", "stream")
+        fields = ('dependency', 'stream')
 
 
 class BuildDepSerializer(serializers.ModelSerializer):
     class Meta:
         model = BuildDependency
-        fields = ("dependency", "stream")
+        fields = ('dependency', 'stream')
 
 
-class UnreleasedVariantSerializer(StrictSerializerMixin,
-                                  serializers.ModelSerializer):
-    variant_id          = serializers.CharField(max_length=100)
-    variant_uid         = serializers.CharField(max_length=200)
-    variant_name        = serializers.CharField(max_length=300)
-    variant_type        = serializers.CharField(max_length=100)
-    variant_version     = serializers.CharField(max_length=100)
-    variant_release     = serializers.CharField(max_length=100)
-    # Default to '00000000' for now since this field will only be used once
-    # other tooling is updated to supply this value. Eventually, this should
-    # not have a default.
-    variant_context     = serializers.CharField(max_length=100, default='00000000')
-    active              = serializers.BooleanField(default=False)
-    koji_tag            = serializers.CharField(max_length=300)
-    modulemd            = serializers.CharField()
-    runtime_deps        = RuntimeDepSerializer(many=True, required=False)
-    build_deps          = BuildDepSerializer(many=True, required=False)
-    rpms                = RPMRelatedField(many=True, read_only=False,
-                                          queryset=RPM.objects.all(),
-                                          required=False)
-
-    class Meta:
-        model = UnreleasedVariant
-        fields = (
-            'variant_id', 'variant_uid', 'variant_name', 'variant_type',
-            'variant_version', 'variant_release', 'variant_context',
-            'koji_tag', 'modulemd', 'runtime_deps', 'build_deps', 'active',
-            'rpms',
-        )
-
-    def validate(self, attrs):
-        # TODO: validate
-        return attrs
+class ModuleSerializerBase(StrictSerializerMixin, serializers.ModelSerializer):
+    """ An abstract class for module related serializer classes to inherit from
+    """
+    runtime_deps = RuntimeDepSerializer(many=True, required=False)
+    build_deps   = BuildDepSerializer(many=True, required=False)
+    rpms         = RPMModuleField(many=True, read_only=False, queryset=RPM.objects.all(),
+                                  required=False)
 
     def create(self, validated_data):
         runtime_deps_data = validated_data.pop('runtime_deps', [])
         build_deps_data = validated_data.pop('build_deps', [])
         rpm_data = validated_data.pop('rpms', [])
 
-        variant = UnreleasedVariant.objects.create(**validated_data)
+        module_obj = Module.objects.create(**validated_data)
 
         for dep_data in runtime_deps_data:
-            RuntimeDependency.objects.create(variant=variant, **dep_data)
+            RuntimeDependency.objects.create(variant=module_obj, **dep_data)
 
         for dep_data in build_deps_data:
-            BuildDependency.objects.create(variant=variant, **dep_data)
+            BuildDependency.objects.create(variant=module_obj, **dep_data)
 
         for rpm in rpm_data:
-            variant.rpms.add(rpm)
+            module_obj.rpms.add(rpm)
 
-        return variant
+        return module_obj
+
+
+class ModuleSerializer(ModuleSerializerBase):
+    # The UID is merely a combination of other fields. See the code in `validate` for more detail.
+    uid = serializers.CharField(read_only=True)
+
+    class Meta:
+        model = Module
+        fields = (
+            'uid', 'name', 'stream', 'version', 'context', 'active', 'koji_tag', 'modulemd',
+            'runtime_deps', 'build_deps', 'rpms',
+        )
+
+    def validate(self, data):
+        # Set the variant_id column to the value of name for backwards compatibility
+        data['variant_id'] = data['name']
+        # Set the default uid to "name:stream:version:context" for convenience and to enforce
+        # standards
+        data['uid'] = ':'.join([data['name'], data['stream'], data['version'], data['context']])
+        return data

--- a/pdc/apps/module/serializers.py
+++ b/pdc/apps/module/serializers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015 Red Hat
+# Copyright (c) 2018 Red Hat
 # Licensed under The MIT License (MIT)
 # http://opensource.org/licenses/MIT
 #

--- a/pdc/apps/module/tests.py
+++ b/pdc/apps/module/tests.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2015 Red Hat
+# Copyright (c) 2018 Red Hat
 # Licensed under The MIT License (MIT)
 # http://opensource.org/licenses/MIT
 #

--- a/pdc/apps/module/tests.py
+++ b/pdc/apps/module/tests.py
@@ -4,14 +4,12 @@
 # Licensed under The MIT License (MIT)
 # http://opensource.org/licenses/MIT
 #
-import json
-
 from django.core.urlresolvers import reverse
 from rest_framework.test import APITestCase
 from rest_framework import status
 
 from pdc.apps.common.test_utils import TestCaseWithChangeSetMixin
-from pdc.apps.module.models import UnreleasedVariant
+from pdc.apps.module.models import Module
 
 
 class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
@@ -19,282 +17,348 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
         'pdc/apps/module/fixtures/test/rpm.json',
     ]
 
-    def test_create_unreleasedvariant1(self):
-        url = reverse('unreleasedvariant-list')
-        data = {
-            'variant_id': "core", 'variant_uid': "Core",
-            'variant_name': "Core", 'variant_version': "0",
-            'variant_release': "1", 'variant_type': 'module',
-            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
-            'modulemd': 'foobar'
+    def setUp(self):
+        self.data = {
+            'name': 'testmodule',
+            'stream': 'f27',
+            'version': '23456789',
+            'context': '12345678',
+            'koji_tag': 'some_tag_f27',
+            'modulemd': 'modulemd',
+            'active': True
         }
-        response = self.client.post(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
-    def test_create_unreleasedvariant2(self):
-        url = reverse('unreleasedvariant-list')
-        data = {
-            'variant_id': "shells", 'variant_uid': "Shells",
-            'variant_name': "Shells", 'variant_version': "0",
-            'variant_release': "1", 'variant_type': 'module',
-            'variant_context': '12345678', 'koji_tag': "module-shells-0-1",
-            'modulemd': 'foobar'}
-        response = self.client.post(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
-    def test_create_two_variants_query_by_active(self):
-        url = reverse('unreleasedvariant-list')
-        data = {
-            'variant_id': "core", 'variant_uid': "Core",
-            'variant_name': "Core", 'variant_version': "0",
-            'variant_release': "1", 'variant_type': 'module',
-            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
-            'modulemd': 'foobar', 'active': False,
+        self.expected = {
+            'active': True,
+            'build_deps': [],
+            'context': '12345678',
+            'koji_tag': 'some_tag_f27',
+            'modulemd': 'modulemd',
+            'name': 'testmodule',
+            'rpms': [],
+            'runtime_deps': [],
+            'stream': 'f27',
+            'uid': 'testmodule:f27:23456789:12345678',
+            'version': '23456789'
         }
-        response = self.client.post(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        data = {
-            'variant_id': "core", 'variant_uid': "Core2",
-            'variant_name': "Core", 'variant_version': "0",
-            'variant_release': "2", 'variant_type': 'module',
-            'variant_context': '12345678', 'koji_tag': "module-core-0-2",
-            'modulemd': 'foobar', 'active': True,
-        }
-        response = self.client.post(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+    @staticmethod
+    def create_module(version='23456789', stream='f27', active=True):
+        obj = Module()
+        obj.name = 'testmodule'
+        obj.stream = stream
+        obj.version = version
+        obj.context = '12345678'
+        obj.koji_tag = 'some_tag_{0}'.format(obj.stream)
+        obj.modulemd = 'modulemd'
+        obj.active = active
+        obj.uid = ':'.join([obj.name, obj.stream, obj.version, obj.context])
+        obj.variant_id = obj.name
+        obj.save()
 
-        data = {'active': True}
-        response = self.client.get(url, data, format='json')
+    def test_create_module(self):
+        url = reverse('modules-list')
+        response = self.client.post(url, self.data, format='json')
+        # Check the response
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data, self.expected)
+        # Check the database
+        module_db = Module.objects.filter(uid='testmodule:f27:23456789:12345678').first()
+        self.assertTrue(module_db.active)
+        self.assertEqual(module_db.build_deps.count(), 0)
+        self.assertEqual(module_db.context, '12345678')
+        self.assertEqual(module_db.koji_tag, 'some_tag_f27')
+        self.assertEqual(module_db.modulemd, 'modulemd')
+        self.assertEqual(module_db.name, 'testmodule')
+        self.assertEqual(module_db.rpms.count(), 0)
+        self.assertEqual(module_db.runtime_deps.count(), 0)
+        self.assertEqual(module_db.stream, 'f27')
+        self.assertEqual(module_db.uid, 'testmodule:f27:23456789:12345678')
+        self.assertEqual(module_db.version, '23456789')
+        # Backwards compatibility checks
+        self.assertEqual(module_db.variant_id, 'testmodule')
+        self.assertEqual(module_db.type, 'module')
+
+    def test_create_module_no_context_error(self):
+        url = reverse('modules-list')
+        self.data.pop('context')
+        response = self.client.post(url, self.data, format='json')
+        # In the "unreleasedvariants" API, we had a default context of '00000000', but in the
+        # "modules" API, it is now a required field
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, {'context': ['This field is required.']})
+
+    def test_create_and_get_module_with_rpms(self):
+        uid_one = self.expected['uid']
+        uid_two = 'testmodule:f27:56789012:12345678'
+        url = reverse('modules-list')
+        self.data['rpms'] = [{
+            'name': 'foobar',
+            'epoch': 0,
+            'version': '1.0.0',
+            'release': '1',
+            'arch': 'src',
+            'srpm_name': 'foobar',
+            'srpm_commit_branch': 'master'
+        }]
+        response = self.client.post(url, self.data, format='json')
+        # Check the response
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.expected['rpms'] = ['foobar-0:1.0.0-1.src.rpm']
+        self.assertEqual(response.data, self.expected)
+        # Check it appears properly with a GET request
+        url_two = reverse('modules-detail', args=[uid_one])
+        response_two = self.client.get(url_two, format='json')
+        self.assertEqual(response_two.data, self.expected)
+        # Create another module
+        self.data['version'] = '56789012'
+        self.data['rpms'] = [{
+            'name': 'foobar',
+            'epoch': 0,
+            'version': '2.0.0',
+            'release': '1',
+            'arch': 'src',
+            'srpm_name': 'foobar',
+            'srpm_commit_branch': 'f27'
+        }]
+        response_three = self.client.post(url, self.data, format='json')
+        # Check the response
+        self.assertEqual(response_three.status_code, status.HTTP_201_CREATED)
+        self.expected['rpms'] = ['foobar-0:2.0.0-1.src.rpm']
+        self.expected['version'] = '56789012'
+        self.expected['uid'] = uid_two
+        self.assertEqual(response_three.data, self.expected)
+
+        # Check that the filters work
+        response_four = self.client.get(url, data={'component_name': 'foobar'}, format='json')
+        self.assertEqual(response_four.data['count'], 2)
+        response_five = self.client.get(
+            url, data={'component_name': 'foobar', 'component_branch': 'master'}, format='json')
+        self.assertEqual(response_five.data['count'], 1)
+        self.assertEqual(response_five.data['results'][0]['uid'], uid_one)
+        response_six = self.client.get(
+            url, data={'component_name': 'foobar', 'component_branch': 'f27'}, format='json')
+        self.assertEqual(response_six.data['count'], 1)
+        self.assertEqual(response_six.data['results'][0]['uid'], uid_two)
+        response_seven = self.client.get(url, data={'component_name': 'python'}, format='json')
+        self.assertEqual(response_seven.data['count'], 0)
+
+    def test_create_and_get_module_with_exist_rpms(self):
+        url = reverse('modules-list')
+        self.data['rpms'] = [{
+            'name': 'bash-doc',
+            'epoch': 0,
+            'version': '1.2.3',
+            'release': '4.b2',
+            'arch': 'x86_64',
+            'srpm_name': 'bash',
+            'srpm_nevra': 'bash-0:1.2.3-4.b2.src'
+        }]
+        response = self.client.post(url, self.data, format='json')
+        # Check the response
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.expected['rpms'] = ['bash-doc-0:1.2.3-4.b2.x86_64.rpm']
+        self.assertEqual(response.data, self.expected)
+        # Check it appears properly with a GET request
+        url_two = reverse('modules-detail', args=['testmodule:f27:23456789:12345678'])
+        response_two = self.client.get(url_two, format='json')
+        self.assertEqual(response_two.data, self.expected)
+
+    def test_create_and_get_module_with_deps(self):
+        self.version = 56789012
+
+        def _increment_version():
+            self.version += 1
+            self.data['version'] = str(self.version)
+            self.expected['version'] = str(self.version)
+            self.expected['uid'] = 'testmodule:f27:{0}:12345678'.format(self.version)
+
+        # Test both build_deps and runtime_deps
+        for dep_type in ('build_deps', 'runtime_deps'):
+            # Reset the dictionaries
+            self.setUp()
+            _increment_version()
+            uid_one = 'testmodule:f27:{0}:12345678'.format(self.version)
+
+            # Create the first module
+            url = reverse('modules-list')
+            self.data[dep_type] = [{'dependency': 'platform', 'stream': 'master'}]
+            response = self.client.post(url, self.data, format='json')
+            # Check the response
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            self.expected[dep_type] = [{'dependency': 'platform', 'stream': 'master'}]
+            self.assertEqual(response.data, self.expected)
+            # Check it appears properly with a GET request
+            url_two = reverse('modules-detail', args=[uid_one])
+            response_two = self.client.get(url_two, format='json')
+            self.assertEqual(response_two.data, self.expected)
+            # Create another module
+            _increment_version()
+            uid_two = 'testmodule:f27:{0}:12345678'.format(self.version)
+            self.data[dep_type] = [{'dependency': 'python', 'stream': 'f27'}]
+            response_three = self.client.post(url, self.data, format='json')
+            self.assertEqual(response_three.status_code, status.HTTP_201_CREATED)
+            self.expected[dep_type] = [{'dependency': 'python', 'stream': 'f27'}]
+            self.assertEqual(response_three.data, self.expected)
+
+            # Test filtering and first start by query for the "unknown" dep
+            dep_key = '{0}_name'.format(dep_type[:-1])
+            response_four = self.client.get(url, {dep_key: 'unknown'}, format='json')
+            self.assertEqual(response_four.status_code, status.HTTP_200_OK)
+            self.assertEqual(response_four.data['count'], 0)
+            # Query for platform
+            response_five = self.client.get(url, data={dep_key: 'platform'}, format='json')
+            self.assertEqual(response_five.status_code, status.HTTP_200_OK)
+            self.assertEqual(response_five.data['count'], 1)
+            self.assertEqual(response_five.data['results'][0]['uid'], uid_one)
+            # Query for python:f27
+            query = {
+                dep_key: 'python',
+                '{0}_stream'.format(dep_type[:-1]): 'f27'
+            }
+            response_six = self.client.get(url, data=query, format='json')
+            self.assertEqual(response_six.status_code, status.HTTP_200_OK)
+            self.assertEqual(response_six.data['count'], 1)
+            self.assertEqual(response_six.data['results'][0]['uid'], uid_two)
+
+    def test_delete_module(self):
+        self.create_module()
+        url = reverse('modules-detail', args=['testmodule:f27:23456789:12345678'])
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        # Check the database
+        module_count = Module.objects.filter(uid='testmodule:f27:23456789:12345678').count()
+        self.assertEqual(module_count, 0)
+
+    def test_patch_module(self):
+        self.create_module()
+        old_uid = 'testmodule:f27:23456789:12345678'
+        new_version = '04191775'
+        new_uid = 'testmodule:f27:{0}:12345678'.format(new_version)
+        url = reverse('modules-detail', args=[old_uid])
+        response = self.client.patch(url, data={'version': new_version}, format='json')
+        self.expected['uid'] = new_uid
+        self.expected['version'] = new_version
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = json.loads(response.content)
-        self.assertEqual(results['count'], 1)
-        self.assertEqual(results['results'][0]['koji_tag'], 'module-core-0-2')
+        self.assertEqual(response.data, self.expected)
+        # Make sure the UID changed
+        module_obj = Module.objects.filter(uid=new_uid).first()
+        self.assertEqual(module_obj.version, new_version)
+        # Make sure the old UID isn't in the database anymore
+        self.assertEqual(Module.objects.filter(uid=old_uid).count(), 0)
 
-    def test_filter_build_deps(self):
-        url = reverse('unreleasedvariant-list')
-
-        # Add variant with 'base-runtime-master' build-dep.
-        data = {
-            'variant_id': "core", 'variant_uid': "Core",
-            'variant_name': "Core", 'variant_version': "0",
-            'variant_release': "1", 'variant_type': 'module',
-            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
-            'modulemd': 'foobar', 'build_deps': [
-                {'dependency': 'base-runtime', 'stream': 'master'}]
-        }
-        response = self.client.post(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
-        # Add variant with 'base-runtime-f26' build-dep.
-        data = {
-            'variant_id': "core3", 'variant_uid': "Core3",
-            'variant_name': "Core3", 'variant_version': "0",
-            'variant_release': "1", 'variant_type': 'module',
-            'variant_context': '12345678', 'koji_tag': "module-core3-0-1",
-            'modulemd': 'foobar', 'build_deps': [
-                {'dependency': 'base-runtime', 'stream': 'f26'}]
-        }
-        response = self.client.post(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
-        # Add variant with 'bootstrap-master' build-dep.
-        data = {
-            'variant_id': "core2", 'variant_uid': "Core2",
-            'variant_name': "Core2", 'variant_version': "0",
-            'variant_release': "1", 'variant_type': 'module',
-            'variant_context': '12345678', 'koji_tag': "module-core2-0-1",
-            'modulemd': 'foobar', 'build_deps': [
-                {'dependency': 'bootstrap', 'stream': 'master'}]
-        }
-        response = self.client.post(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
-        # Try to get unknown build-dep
-        data = {'build_dep_name': "unknown"}
-        response = self.client.get(url, data, format='json')
+    def test_put_module(self):
+        self.create_module()
+        old_uid = 'testmodule:f27:23456789:12345678'
+        new_version = '04191775'
+        new_uid = 'testmodule:f27:{0}:12345678'.format(new_version)
+        url = reverse('modules-detail', args=[old_uid])
+        self.data['version'] = new_version
+        response = self.client.put(url, data=self.data, format='json')
+        self.expected['uid'] = new_uid
+        self.expected['version'] = new_version
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 0)
+        self.assertEqual(response.data, self.expected)
+        # Make sure the UID changed
+        module_obj = Module.objects.filter(uid=new_uid).first()
+        self.assertEqual(module_obj.version, new_version)
+        # Make sure the old UID isn't in the database anymore
+        self.assertEqual(Module.objects.filter(uid=old_uid).count(), 0)
 
-        # Try to get base-runtime build-dep
-        data = {'build_dep_name': "base-runtime"}
-        response = self.client.get(url, data, format='json')
-
+    def test_get_modules(self):
+        self.create_module(version='23456789', active=True)
+        self.create_module(version='89012345', active=False)
+        url = reverse('modules-list')
+        response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 2)
-
-        # Try to get base-runtime-master build-dep
-        data = {'build_dep_name': "base-runtime",
-                'build_dep_stream': "master"}
-        response = self.client.get(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 1)
-        self.assertEqual(response.data['results'][0]["variant_uid"], "Core")
-
-    def test_create_with_new_rpms(self):
-        url = reverse('unreleasedvariant-list')
-        data = {
-            'variant_id': "core", 'variant_uid': "Core",
-            'variant_name': "Core", 'variant_version': "0",
-            'variant_release': "1", 'variant_type': 'module',
-            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
-            'modulemd': 'foobar', 'active': False,
-            'rpms': [{'name': 'new_rpm', 'epoch': 0, 'version': '1.0.0',
-                        'release': '1', 'arch': 'src', 'srpm_name': 'new_srpm'}]
+        expected_results = {
+            'count': 2,
+            'next': None,
+            'previous': None,
+            'results': [
+                self.expected,
+                {
+                    'active': False,
+                    'build_deps': [],
+                    'context': '12345678',
+                    'koji_tag': 'some_tag_f27',
+                    'modulemd': 'modulemd',
+                    'name': 'testmodule',
+                    'rpms': [],
+                    'runtime_deps': [],
+                    'stream': 'f27',
+                    'uid': 'testmodule:f27:89012345:12345678',
+                    'version': '89012345'
+                }
+            ]
         }
-        response = self.client.post(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertNumChanges([2])
-        self.assertIn('new_rpm', response.content)
+        self.assertEqual(response.data, expected_results)
 
-    def test_create_and_delete_unreleasedvariant(self):
-        url = reverse('unreleasedvariant-list')
-        data = {
-            'variant_id': 'core', 'variant_uid': 'core-test-123',
-            'variant_name': 'core', 'variant_version': '0',
-            'variant_release': '1', 'variant_type': 'module',
-            'variant_context': '12345678', 'koji_tag': 'module-core-0-1',
-            'modulemd': 'foobar', 'active': False
+    def test_filter_modules(self):
+        self.create_module(version='23456789', stream='f27', active=True)
+        self.create_module(version='89012345', stream='master', active=False)
+        url = reverse('modules-list')
+        expected_results_f27 = {
+            'count': 1,
+            'next': None,
+            'previous': None,
+            'results': [self.expected]
         }
-        response = self.client.post(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        url_two = reverse('unreleasedvariant-detail', args=['core-test-123'])
-        response_two = self.client.delete(url_two)
-        self.assertEqual(response_two.status_code, status.HTTP_204_NO_CONTENT)
-
-    def test_filter_by_rpms(self):
-        url = reverse('unreleasedvariant-list')
-        # add a variant with rpm 'foobar' from branch 'master'
-        data = {
-            'variant_id': "core", 'variant_uid': "Core",
-            'variant_name': "Core", 'variant_version': "0",
-            'variant_release': "1", 'variant_type': 'module',
-            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
-            'modulemd': 'foobar', 'active': True,
-            'rpms': [{'name': 'foobar', 'epoch': 0, 'version': '1.0.0',
-                      'release': '1', 'arch': 'src', 'srpm_name': 'foobar',
-                      'srpm_commit_branch': 'master'}]
+        expected_results_master = {
+            'count': 1,
+            'next': None,
+            'previous': None,
+            'results': [{
+                'active': False,
+                'build_deps': [],
+                'context': '12345678',
+                'koji_tag': 'some_tag_master',
+                'modulemd': 'modulemd',
+                'name': 'testmodule',
+                'rpms': [],
+                'runtime_deps': [],
+                'stream': 'master',
+                'uid': 'testmodule:master:89012345:12345678',
+                'version': '89012345'
+            }]
         }
-        response = self.client.post(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertIn('foobar', response.content)
-
-        # add another variant with rpm 'foobar' from branch 'rawhide'
-        data = {
-            'variant_id': "core2", 'variant_uid': "Core2",
-            'variant_name': "Core2", 'variant_version': "0",
-            'variant_release': "1", 'variant_type': 'module',
-            'variant_context': '12345678', 'koji_tag': "module-core2-0-1",
-            'modulemd': 'foobar', 'active': True,
-            'rpms': [{'name': 'foobar', 'epoch': 0, 'version': '2.0.0',
-                      'release': '1', 'arch': 'src', 'srpm_name': 'foobar',
-                      'srpm_commit_branch': 'rawhide'}]
+        expected_results_both = {
+            'count': 2,
+            'next': None,
+            'previous': None,
+            'results': [
+                expected_results_f27['results'][0],
+                expected_results_master['results'][0]
+            ]
         }
-        response = self.client.post(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertIn('foobar', response.content)
-
-        # query modules with rpm name
-        data = {'component_name': 'foobar'}
-        response = self.client.get(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 2)
-        self.assertIn("Core", [x['variant_uid'] for x in response.data['results']])
-        self.assertIn("Core2", [x['variant_uid'] for x in response.data['results']])
-
-        # query modules with rpm name and branch
-        data = {'component_name': 'foobar', 'component_branch': 'master'}
-        response = self.client.get(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 1)
-        self.assertIn("Core", [x['variant_uid'] for x in response.data['results']])
-        self.assertNotIn("Core2", [x['variant_uid'] for x in response.data['results']])
-
-        data = {'component_name': 'foobar', 'component_branch': 'rawhide'}
-        response = self.client.get(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 1)
-        self.assertNotIn("Core", [x['variant_uid'] for x in response.data['results']])
-        self.assertIn("Core2", [x['variant_uid'] for x in response.data['results']])
-
-    def test_create_with_exist_rpms(self):
-        url = reverse('unreleasedvariant-list')
-        data = {
-            'variant_id': "core", 'variant_uid': "Core",
-            'variant_name': "Core", 'variant_version': "0",
-            'variant_release': "1", 'variant_type': 'module',
-            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
-            'modulemd': 'foobar', 'active': False,
-            'rpms': [{
-                "name": "bash-doc",
-                "epoch": 0,
-                "version": "1.2.3",
-                "release": "4.b2",
-                "arch": "x86_64",
-                "srpm_name": "bash",
-                "srpm_nevra": "bash-0:1.2.3-4.b2.src"}]
+        filters = {
+            'f27': [
+                {'stream': 'f27'},
+                {'active': True},
+                {'koji_tag': 'some_tag_f27'},
+                {'uid': 'testmodule:f27:23456789:12345678'},
+                {'stream': 'f27', 'active': True}
+            ],
+            'both': [
+                {'context': '12345678'},
+                {'name': 'testmodule'},
+            ],
+            'master': [
+                {'active': False},
+                {'koji_tag': 'some_tag_master'},
+                {'uid': 'testmodule:master:89012345:12345678'},
+                {'stream': 'master', 'active': False}
+            ],
         }
-
-        response = self.client.post(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertNumChanges([1])
-        self.assertIn('bash-doc', response.content)
-
-        # Try to get the module with component "bash".
-        response = self.client.get(url + '?component_name=bash', format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data.get('count'), 1)
-        self.assertEqual(response.data['results'][0]["variant_uid"], "Core")
-
-        # Try to get a module with unknown component.
-        response = self.client.get(url + '?component_name=unknown', format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data.get('count'), 0)
-
-    def test_create_and_update_unreleasedvariant(self):
-        url = reverse('unreleasedvariant-list')
-        data = {
-            'variant_id': "core", 'variant_uid': "coretest123",
-            'variant_name': "core", 'variant_version': "0",
-            'variant_release': "1", 'variant_type': 'module',
-            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
-            'modulemd': 'foobar', 'active': False
-        }
-        response = self.client.post(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        url_two = reverse('unreleasedvariant-detail', args=['coretest123'])
-        data_two = {'active': True}
-        response_two = self.client.patch(url_two, data_two, format='json')
-        self.assertEqual(response_two.status_code, status.HTTP_200_OK)
-        uv = UnreleasedVariant.objects.filter(
-            variant_uid='coretest123').first()
-        self.assertTrue(uv.active)
-
-    def test_create_unreleasedvariant_default_context(self):
-        url = reverse('unreleasedvariant-list')
-        data = {
-            'variant_id': "core", 'variant_uid': "coretest123",
-            'variant_name': "Core", 'variant_version': "0",
-            'variant_release': "1", 'variant_type': 'module',
-            'koji_tag': "module-core-0-1", 'modulemd': 'foobar'
-        }
-        response = self.client.post(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        uv = UnreleasedVariant.objects.filter(
-            variant_uid='coretest123').first()
-        self.assertEqual(uv.variant_context, '00000000')
-
-    def test_create_unreleasedvariant_not_default_context(self):
-        url = reverse('unreleasedvariant-list')
-        data = {
-            'variant_id': "core", 'variant_uid': "coretest123",
-            'variant_name': "Core", 'variant_version': "0",
-            'variant_release': "1", 'variant_type': 'module',
-            'variant_context': 'a23d56a8', 'koji_tag': "module-core-0-1",
-            'modulemd': 'foobar'
-        }
-        response = self.client.post(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        uv = UnreleasedVariant.objects.filter(
-            variant_uid='coretest123').first()
-        self.assertEqual(uv.variant_context, 'a23d56a8')
+        for expected, item_filters in filters.items():
+            if expected == 'f27':
+                expected = expected_results_f27
+            elif expected == 'master':
+                expected = expected_results_master
+            elif expected == 'both':
+                expected = expected_results_both
+            else:
+                raise ValueError('"{0}" is an invalid value'.format(expected))
+            for item_filter in item_filters:
+                response = self.client.get(url, data=item_filter, format='json')
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(response.data, expected)

--- a/pdc/apps/module/views.py
+++ b/pdc/apps/module/views.py
@@ -5,169 +5,84 @@
 #
 
 from pdc.apps.common import viewsets
-from .models import UnreleasedVariant
-from .serializers import UnreleasedVariantSerializer
-from .filters import UnreleasedVariantFilter
+from pdc.apps.module.models import Module
+from pdc.apps.module.serializers import ModuleSerializer
+from pdc.apps.module.filters import ModuleFilter
 
 
-class UnreleasedVariantViewSet(viewsets.PDCModelViewSet):
+class ModuleViewSet(viewsets.PDCModelViewSet):
     """
     ##Overview##
 
-    This page shows the usage of the **Module API**, please see the
-    following for more details.
-
-    ##Test tools##
-
-    You can use ``curl`` in terminal, with -X _method_ (GET|POST|PUT|DELETE),
-    -d _data_ (a json string). or GUI plugins for
-    browsers, such as ``RESTClient``, ``RESTConsole``.
-
+    This page shows the usage of the **Module API**, please see the following for more details.
     """
-    model = UnreleasedVariant
-    queryset = UnreleasedVariant.objects.all().order_by('variant_uid')
-    serializer_class = UnreleasedVariantSerializer
-    filter_class = UnreleasedVariantFilter
-    lookup_field = 'variant_uid'
+    model = Module
+    # Only show the items in the database of type 'module'. The type in the "unreleasedvariants"
+    # API is a freeform text field but in this API, the type field is not exposed and just defaults
+    # to 'module' in the database for backwards-compatibility.
+    queryset = Module.objects.filter(type='module').order_by('uid')
+    filter_class = ModuleFilter
+    serializer_class = ModuleSerializer
+    lookup_field = 'uid'
 
     def list(self, request, *args, **kwargs):
         """
         __Method__:
         GET
 
-        __URL__: $LINK:unreleasedvariant-list$
+        __URL__: $LINK:modules-list$
 
         __Query Params__:
 
         %(FILTERS)s
 
-        __Response__:
+        __Paged Response__:
 
-            # paged lists
-            {
-                "count": int,
-                "next": url,
-                "previous": url,
-                "results": [
-                    {
-                        "variant_id": string,
-                        "variant_uid": string,
-                        "variant_name": string,
-                        "variant_type": string,
-                        "variant_version": string,
-                        "variant_release": string,
-                        "variant_context": string,
-                        "koji_tag": string,
-                        "modulemd": string,
-                        "active": bool,
-                        "runtime_deps": [{"dependency": string, "stream": string}, ... ],
-                        "build_deps": [{"dependency": string, "stream": string}, ... ],
-                        "rpms": [string, ... ]
-                    },
-                    ...
-                ]
-            }
+        %(SERIALIZER)s
         """
-        return super(UnreleasedVariantViewSet, self).list(request, *args, **kwargs)
+        return super(ModuleViewSet, self).list(request, *args, **kwargs)
 
     def retrieve(self, request, *args, **kwargs):
         """
         __Method__:
         GET
 
-        __URL__: $LINK:unreleasedvariant-detail:variant_uid$
+        __URL__: $LINK:modules-detail:uid$
 
         __Response__:
 
-            {
-                "variant_id": string,
-                "variant_uid": string,
-                "variant_name": string,
-                "variant_type": string,
-                "variant_version": string,
-                "variant_release": string,
-                "variant_context": string,
-                "koji_tag": string,
-                "modulemd": string,
-                "active": bool,
-                "runtime_deps": [{"dependency": string, "stream": string}, ... ],
-                "build_deps": [{"dependency": string, "stream": string}, ... ],
-                "rpms": [string, ... ]
-            }
+        %(SERIALIZER)s
         """
-        return super(UnreleasedVariantViewSet, self).retrieve(request, *args, **kwargs)
+        return super(ModuleViewSet, self).retrieve(request, *args, **kwargs)
 
     def create(self, request, *args, **kwargs):
         """
         __Method__:
         POST
 
-        __URL__: $LINK:unreleasedvariant-list$
+        __URL__: $LINK:modules-list$
 
         __Data__:
 
-            {
-                "variant_id": string,     # required
-                "variant_uid": string,    # required
-                "variant_name": string,   # required
-                "variant_type": string,   # required
-                "variant_version": string,# version of this particular variant
-                "variant_release": string,# release of this particular variant
-                "variant_context": string,
-                "koji_tag": string,       # required
-                "modulemd": string,       # required
-                "active": bool,           # required
-                "runtime_deps": [{"dependency": string, "stream": string}, ... ],
-                "build_deps": [{"dependency": string, "stream": string}, ... ],
-                "rpms": [string, ... ]
-            }
+        %(WRITABLE_SERIALIZER)s
 
         __Response__:
 
-            {
-                "variant_id": string,
-                "variant_uid": string,
-                "variant_name": string,
-                "variant_type": string,
-                "variant_version": string,
-                "variant_release": string,
-                "variant_context": string,
-                "koji_tag": string,
-                "modulemd": string,
-                "active": bool,
-                "runtime_deps": [{"dependency": string, "stream": string}, ... ],
-                "build_deps": [{"dependency": string, "stream": string}, ... ],
-                "rpms": [string, ... ]
-            }
+        %(SERIALIZER)s
 
         __Example__:
 
-            curl -X POST -H "Content-Type: application/json" $URL:unreleasedvariant-list$ \\
-                    -d '{ "variant_id": "core", "variant_uid": "Core", "variant_name": "Minimalistic Core", "variant_type": "module", "variant_version": "master", "variant_release": "20170101", "variant_context": "2f345c78", "koji_tag": "foobar", "active": false }'
-            # output
-            {
-                "variant_id": "core",
-                "variant_uid": "Core",
-                "variant_name": "Minimalistic Core",
-                "variant_type": "module",
-                "variant_version": "master",
-                "variant_release": "20170101",
-                "variant_context": string,
-                "koji_tag": "foobar",
-                "active": false,
-                "runtime_deps": [],
-                "build_deps": [],
-                "rpms": [],
-            }
+            curl -X POST -H "Content-Type: application/json" $URL:modules-list$ \\
+                -d '{ "name": "testmodule", "stream": "f28", "version": "20180123171544", "context": "2f345c78", "koji_tag": "module-ce2adf69caf0e1b5", "modulemd": "data here" }'
         """
-        return super(UnreleasedVariantViewSet, self).create(request, **kwargs)
+        return super(ModuleViewSet, self).create(request, **kwargs)
 
     def destroy(self, request, *args, **kwargs):
         """
         __Method__:
         DELETE
 
-        __URL__: $LINK:unreleasedvariant-detail:variant_uid$
+        __URL__: $LINK:modules-detail:uid$
 
         __Response__:
 
@@ -175,56 +90,28 @@ class UnreleasedVariantViewSet(viewsets.PDCModelViewSet):
 
         __Example__:
 
-            curl -X DELETE -H "Content-Type: application/json" $URL:unreleasedvariant-detail:4181$
+            curl -X DELETE -H "Content-Type: application/json" $URL:modules-detail:uid_here$
         """
-        return super(UnreleasedVariantViewSet, self).destroy(request, **kwargs)
+        return super(ModuleViewSet, self).destroy(request, **kwargs)
 
     def update(self, request, *args, **kwargs):
         """
         __Method__:
         PUT/PATCH
 
-        __URL__: $LINK:unreleasedvariant-detail:variant_uid$
+        __URL__: $LINK:modules-detail:uid$
 
         __Data__:
 
-            {
-                "variant_id": string,     # required
-                "variant_uid": string,    # required
-                "variant_name": string,   # required
-                "variant_type": string,   # required
-                "variant_version": string,# version of this particular variant
-                "variant_release": string,# release of this particular variant
-                "variant_context": string,# context of this particular variant
-                "koji_tag": string,       # required
-                "modulemd": string,       # required
-                "active": bool,           # required
-                "runtime_deps": [{"dependency": string, "stream": string}, ... ],
-                "build_deps": [{"dependency": string, "stream": string}, ... ],
-                "rpms": [string, ... ]
-            }
+        %(WRITABLE_SERIALIZER)s
 
         __Response__:
 
-            {
-                "variant_id": string,
-                "variant_uid": string,
-                "variant_name": string,
-                "variant_type": string,
-                "variant_version": string,
-                "variant_release": string,
-                "variant_context": string,
-                "koji_tag": string,
-                "modulemd": string,
-                "active": bool,
-                "runtime_deps": [{"dependency": string, "stream": string}, ... ],
-                "build_deps": [{"dependency": string, "stream": string}, ... ],
-                "rpms": [string, ... ]
-            }
+        %(SERIALIZER)s
 
         __Example__:
 
-            curl -X PATCH -d '{ "active": true}' -H "Content-Type: application/json" \\
-                $URL:unreleasedvariant-detail:testmodule-master-20170301215520$
+            curl -X PATCH -d '{ "active": true }' -H "Content-Type: application/json" \\
+                $URL:modules-detail:uid_here$
         """
-        return super(UnreleasedVariantViewSet, self).update(request, *args, **kwargs)
+        return super(ModuleViewSet, self).update(request, *args, **kwargs)

--- a/pdc/apps/module/views.py
+++ b/pdc/apps/module/views.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015 Red Hat
+# Copyright (c) 2018 Red Hat
 # Licensed under The MIT License (MIT)
 # http://opensource.org/licenses/MIT
 #

--- a/pdc/apps/unreleasedvariant/__init__.py
+++ b/pdc/apps/unreleasedvariant/__init__.py
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2018 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#
+default_app_config = 'pdc.apps.unreleasedvariant.apps.UnreleasedVariantConfig'

--- a/pdc/apps/unreleasedvariant/apps.py
+++ b/pdc/apps/unreleasedvariant/apps.py
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2018 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#
+from django.apps import AppConfig
+
+
+class UnreleasedVariantConfig(AppConfig):
+    name = 'pdc.apps.unreleasedvariant'

--- a/pdc/apps/unreleasedvariant/filters.py
+++ b/pdc/apps/unreleasedvariant/filters.py
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2018 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#
+import django_filters
+
+from pdc.apps.module.models import Module
+from pdc.apps.module.filters import ModuleFilterBase
+
+
+class UnreleasedVariantFilter(ModuleFilterBase):
+    variant_id      = django_filters.CharFilter(name='variant_id', lookup_type='iexact')
+    variant_uid     = django_filters.CharFilter(name='uid', lookup_type='iexact')
+    variant_name    = django_filters.CharFilter(name='name', lookup_type='iexact')
+    variant_type    = django_filters.CharFilter(name='type', lookup_type='iexact')
+    variant_version = django_filters.CharFilter(name='stream', lookup_type='iexact')
+    variant_release = django_filters.CharFilter(name='version', lookup_type='iexact')
+    variant_context = django_filters.CharFilter(name='context', lookup_type='iexact')
+
+    class Meta:
+        model = Module
+        fields = ('koji_tag', 'modulemd', 'runtime_dep_name', 'runtime_dep_stream',
+                  'build_dep_name', 'build_dep_stream', 'component_name', 'component_branch')

--- a/pdc/apps/unreleasedvariant/routers.py
+++ b/pdc/apps/unreleasedvariant/routers.py
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2018 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#
+from pdc.apps.unreleasedvariant.views import UnreleasedVariantViewSet
+from pdc.apps.utils.SortedRouter import router
+
+
+router.register(r'unreleasedvariants', UnreleasedVariantViewSet, base_name='unreleasedvariants')

--- a/pdc/apps/unreleasedvariant/serializers.py
+++ b/pdc/apps/unreleasedvariant/serializers.py
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2018 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#
+from rest_framework import serializers
+
+from pdc.apps.module.models import Module
+from pdc.apps.module.serializers import ModuleSerializerBase
+
+
+class UnreleasedVariantSerializer(ModuleSerializerBase):
+    variant_id = serializers.CharField(max_length=100, required=True, allow_null=False)
+    variant_uid = serializers.CharField(source='uid')
+    variant_name = serializers.CharField(source='name')
+    variant_type = serializers.CharField(source='type')
+    variant_version = serializers.CharField(source='stream')
+    variant_release = serializers.CharField(source='version')
+    variant_context = serializers.CharField(source='context', default='00000000')
+
+    class Meta:
+        model = Module
+        fields = (
+            'variant_id', 'variant_uid', 'variant_name', 'variant_type', 'variant_version',
+            'variant_release', 'variant_context', 'koji_tag', 'modulemd', 'runtime_deps',
+            'build_deps', 'active', 'rpms',
+        )

--- a/pdc/apps/unreleasedvariant/tests.py
+++ b/pdc/apps/unreleasedvariant/tests.py
@@ -1,0 +1,331 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#
+import json
+
+from django.core.urlresolvers import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
+
+from pdc.apps.common.test_utils import TestCaseWithChangeSetMixin
+from pdc.apps.module.models import Module
+
+
+class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
+    fixtures = [
+        'pdc/apps/module/fixtures/test/rpm.json',
+    ]
+
+    def test_create_unreleasedvariant1(self):
+        url = reverse('unreleasedvariants-list')
+        data = {
+            'variant_id': "core", 'variant_uid': "Core",
+            'variant_name': "Core", 'variant_version': "0",
+            'variant_release': "1", 'variant_type': 'module',
+            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
+            'modulemd': 'foobar'
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_create_unreleasedvariant2(self):
+        url = reverse('unreleasedvariants-list')
+        data = {
+            'variant_id': "shells", 'variant_uid': "Shells",
+            'variant_name': "Shells", 'variant_version': "0",
+            'variant_release': "1", 'variant_type': 'module',
+            'variant_context': '12345678', 'koji_tag': "module-shells-0-1",
+            'modulemd': 'foobar'}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_create_two_variants_query_by_active(self):
+        url = reverse('unreleasedvariants-list')
+        data = {
+            'variant_id': "core", 'variant_uid': "Core",
+            'variant_name': "Core", 'variant_version': "0",
+            'variant_release': "1", 'variant_type': 'module',
+            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
+            'modulemd': 'foobar', 'active': False,
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        data = {
+            'variant_id': "core", 'variant_uid': "Core2",
+            'variant_name': "Core", 'variant_version': "0",
+            'variant_release': "2", 'variant_type': 'module',
+            'variant_context': '12345678', 'koji_tag': "module-core-0-2",
+            'modulemd': 'foobar', 'active': True,
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        data = {'active': True}
+        response = self.client.get(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = json.loads(response.content)
+        self.assertEqual(results['count'], 1)
+        self.assertEqual(results['results'][0]['koji_tag'], 'module-core-0-2')
+
+    def test_filter_build_deps(self):
+        url = reverse('unreleasedvariants-list')
+
+        # Add variant with 'base-runtime-master' build-dep.
+        data = {
+            'variant_id': "core", 'variant_uid': "Core",
+            'variant_name': "Core", 'variant_version': "0",
+            'variant_release': "1", 'variant_type': 'module',
+            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
+            'modulemd': 'foobar', 'build_deps': [
+                {'dependency': 'base-runtime', 'stream': 'master'}]
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Add variant with 'base-runtime-f26' build-dep.
+        data = {
+            'variant_id': "core3", 'variant_uid': "Core3",
+            'variant_name': "Core3", 'variant_version': "0",
+            'variant_release': "1", 'variant_type': 'module',
+            'variant_context': '12345678', 'koji_tag': "module-core3-0-1",
+            'modulemd': 'foobar', 'build_deps': [
+                {'dependency': 'base-runtime', 'stream': 'f26'}]
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Add variant with 'bootstrap-master' build-dep.
+        data = {
+            'variant_id': "core2", 'variant_uid': "Core2",
+            'variant_name': "Core2", 'variant_version': "0",
+            'variant_release': "1", 'variant_type': 'module',
+            'variant_context': '12345678', 'koji_tag': "module-core2-0-1",
+            'modulemd': 'foobar', 'build_deps': [
+                {'dependency': 'bootstrap', 'stream': 'master'}]
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Try to get unknown build-dep
+        data = {'build_dep_name': "unknown"}
+        response = self.client.get(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 0)
+
+        # Try to get base-runtime build-dep
+        data = {'build_dep_name': "base-runtime"}
+        response = self.client.get(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 2)
+
+        # Try to get base-runtime-master build-dep
+        data = {'build_dep_name': "base-runtime",
+                'build_dep_stream': "master"}
+        response = self.client.get(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['results'][0]["variant_uid"], "Core")
+
+    def test_create_with_new_rpms(self):
+        url = reverse('unreleasedvariants-list')
+        data = {
+            'variant_id': "core", 'variant_uid': "Core",
+            'variant_name': "Core", 'variant_version': "0",
+            'variant_release': "1", 'variant_type': 'module',
+            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
+            'modulemd': 'foobar', 'active': False,
+            'rpms': [{'name': 'new_rpm', 'epoch': 0, 'version': '1.0.0',
+                        'release': '1', 'arch': 'src', 'srpm_name': 'new_srpm'}]
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertNumChanges([2])
+        self.assertIn('new_rpm', response.content)
+
+    def test_create_and_delete_unreleasedvariant(self):
+        url = reverse('unreleasedvariants-list')
+        data = {
+            'variant_id': 'core', 'variant_uid': 'core-test-123',
+            'variant_name': 'core', 'variant_version': '0',
+            'variant_release': '1', 'variant_type': 'module',
+            'variant_context': '12345678', 'koji_tag': 'module-core-0-1',
+            'modulemd': 'foobar', 'active': False
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        url_two = reverse('unreleasedvariants-detail', args=['core-test-123'])
+        response_two = self.client.delete(url_two)
+        self.assertEqual(response_two.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_filter_by_rpms(self):
+        url = reverse('unreleasedvariants-list')
+        # add a variant with rpm 'foobar' from branch 'master'
+        data = {
+            'variant_id': "core", 'variant_uid': "Core",
+            'variant_name': "Core", 'variant_version': "0",
+            'variant_release': "1", 'variant_type': 'module',
+            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
+            'modulemd': 'foobar', 'active': True,
+            'rpms': [{'name': 'foobar', 'epoch': 0, 'version': '1.0.0',
+                      'release': '1', 'arch': 'src', 'srpm_name': 'foobar',
+                      'srpm_commit_branch': 'master'}]
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertIn('foobar', response.content)
+
+        # add another variant with rpm 'foobar' from branch 'rawhide'
+        data = {
+            'variant_id': "core2", 'variant_uid': "Core2",
+            'variant_name': "Core2", 'variant_version': "0",
+            'variant_release': "1", 'variant_type': 'module',
+            'variant_context': '12345678', 'koji_tag': "module-core2-0-1",
+            'modulemd': 'foobar', 'active': True,
+            'rpms': [{'name': 'foobar', 'epoch': 0, 'version': '2.0.0',
+                      'release': '1', 'arch': 'src', 'srpm_name': 'foobar',
+                      'srpm_commit_branch': 'rawhide'}]
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertIn('foobar', response.content)
+
+        # query modules with rpm name
+        data = {'component_name': 'foobar'}
+        response = self.client.get(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 2)
+        self.assertIn("Core", [x['variant_uid'] for x in response.data['results']])
+        self.assertIn("Core2", [x['variant_uid'] for x in response.data['results']])
+
+        # query modules with rpm name and branch
+        data = {'component_name': 'foobar', 'component_branch': 'master'}
+        response = self.client.get(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 1)
+        self.assertIn("Core", [x['variant_uid'] for x in response.data['results']])
+        self.assertNotIn("Core2", [x['variant_uid'] for x in response.data['results']])
+
+        data = {'component_name': 'foobar', 'component_branch': 'rawhide'}
+        response = self.client.get(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 1)
+        self.assertNotIn("Core", [x['variant_uid'] for x in response.data['results']])
+        self.assertIn("Core2", [x['variant_uid'] for x in response.data['results']])
+
+    def test_create_with_exist_rpms(self):
+        url = reverse('unreleasedvariants-list')
+        data = {
+            'variant_id': "core", 'variant_uid': "Core",
+            'variant_name': "Core", 'variant_version': "0",
+            'variant_release': "1", 'variant_type': 'module',
+            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
+            'modulemd': 'foobar', 'active': False,
+            'rpms': [{
+                "name": "bash-doc",
+                "epoch": 0,
+                "version": "1.2.3",
+                "release": "4.b2",
+                "arch": "x86_64",
+                "srpm_name": "bash",
+                "srpm_nevra": "bash-0:1.2.3-4.b2.src"}]
+        }
+
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertNumChanges([1])
+        self.assertIn('bash-doc', response.content)
+
+        # Try to get the module with component "bash".
+        response = self.client.get(url + '?component_name=bash', format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('count'), 1)
+        self.assertEqual(response.data['results'][0]["variant_uid"], "Core")
+
+        # Try to get a module with unknown component.
+        response = self.client.get(url + '?component_name=unknown', format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('count'), 0)
+
+    def test_create_and_update_unreleasedvariant(self):
+        url = reverse('unreleasedvariants-list')
+        data = {
+            'variant_id': "core", 'variant_uid': "coretest123",
+            'variant_name': "core", 'variant_version': "0",
+            'variant_release': "1", 'variant_type': 'module',
+            'variant_context': '12345678', 'koji_tag': "module-core-0-1",
+            'modulemd': 'foobar', 'active': False
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        url_two = reverse('unreleasedvariants-detail', args=['coretest123'])
+        data_two = {'active': True}
+        response_two = self.client.patch(url_two, data_two, format='json')
+        self.assertEqual(response_two.status_code, status.HTTP_200_OK)
+        uv = Module.objects.filter(uid='coretest123').first()
+        self.assertTrue(uv.active)
+
+    def test_create_unreleasedvariant_default_context(self):
+        url = reverse('unreleasedvariants-list')
+        data = {
+            'variant_id': "core", 'variant_uid': "coretest123",
+            'variant_name': "Core", 'variant_version': "0",
+            'variant_release': "1", 'variant_type': 'module',
+            'koji_tag': "module-core-0-1", 'modulemd': 'foobar'
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        uv = Module.objects.filter(uid='coretest123').first()
+        self.assertEqual(uv.context, '00000000')
+
+    def test_create_unreleasedvariant_not_default_context(self):
+        url = reverse('unreleasedvariants-list')
+        data = {
+            'variant_id': "core", 'variant_uid': "coretest123",
+            'variant_name': "Core", 'variant_version': "0",
+            'variant_release': "1", 'variant_type': 'module',
+            'variant_context': 'a23d56a8', 'koji_tag': "module-core-0-1",
+            'modulemd': 'foobar'
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        uv = Module.objects.filter(uid='coretest123').first()
+        self.assertEqual(uv.context, 'a23d56a8')
+
+    def test_v2_compatibility_unreleasedvariant(self):
+        data = {
+            'name': 'testmodule',
+            'stream': 'f27',
+            'version': '23456789',
+            'context': '12345678',
+            'koji_tag': 'some_tag_f27',
+            'modulemd': 'modulemd',
+            'active': True
+        }
+        url = reverse('modules-list')
+        response = self.client.post(url, data, format='json')
+        # Check the response
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        url_two = reverse('unreleasedvariants-detail', args=['testmodule:f27:23456789:12345678'])
+        response = self.client.get(url_two, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected = {
+            'active': True,
+            'build_deps': [],
+            'variant_context': '12345678',
+            'koji_tag': 'some_tag_f27',
+            'modulemd': 'modulemd',
+            'variant_name': 'testmodule',
+            'rpms': [],
+            'runtime_deps': [],
+            'variant_version': 'f27',
+            'variant_uid': 'testmodule:f27:23456789:12345678',
+            'variant_release': '23456789',
+            'variant_id': 'testmodule',
+            'variant_type': 'module'
+        }
+        self.assertEqual(response.data, expected)

--- a/pdc/apps/unreleasedvariant/views.py
+++ b/pdc/apps/unreleasedvariant/views.py
@@ -1,0 +1,114 @@
+#
+# Copyright (c) 2018 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#
+from pdc.apps.common import viewsets
+from pdc.apps.module.models import Module
+from pdc.apps.unreleasedvariant.serializers import UnreleasedVariantSerializer
+from pdc.apps.unreleasedvariant.filters import UnreleasedVariantFilter
+
+
+class UnreleasedVariantViewSet(viewsets.PDCModelViewSet):
+    """
+    # This API is deprecated. Please use $LINK:modules-list$.#
+    ##Overview##
+
+    This page shows the usage of the **Module API**, please see the following for more details.
+    """
+    model = Module
+    queryset = Module.objects.all().order_by('uid')
+    filter_class = UnreleasedVariantFilter
+    serializer_class = UnreleasedVariantSerializer
+    lookup_field = 'uid'
+
+    def list(self, request, *args, **kwargs):
+        """
+        __Method__:
+        GET
+
+        __URL__: $LINK:unreleasedvariants-list$
+
+        __Query Params__:
+
+        %(FILTERS)s
+
+        __Paged Response__:
+
+        %(SERIALIZER)s
+        """
+        return super(UnreleasedVariantViewSet, self).list(request, *args, **kwargs)
+
+    def retrieve(self, request, *args, **kwargs):
+        """
+        __Method__:
+        GET
+
+        __URL__: $LINK:unreleasedvariants-detail:variant_uid$
+
+        __Response__:
+
+        %(SERIALIZER)s
+        """
+        return super(UnreleasedVariantViewSet, self).retrieve(request, *args, **kwargs)
+
+    def create(self, request, *args, **kwargs):
+        """
+        __Method__:
+        POST
+
+        __URL__: $LINK:unreleasedvariants-list$
+
+        __Data__:
+
+        %(WRITABLE_SERIALIZER)s
+
+        __Response__:
+
+        %(SERIALIZER)s
+
+        __Example__:
+
+            curl -X POST -H "Content-Type: application/json" $URL:unreleasedvariants-list$ \\
+                    -d '{ "variant_id": "core", "variant_uid": "Core", "variant_name": "Minimalistic Core", "variant_type": "module", "variant_version": "master", "variant_release": "20170101", "variant_context": "2f345c78", "koji_tag": "foobar", "active": false }'
+        """
+        return super(UnreleasedVariantViewSet, self).create(request, **kwargs)
+
+    def destroy(self, request, *args, **kwargs):
+        """
+        __Method__:
+        DELETE
+
+        __URL__: $LINK:unreleasedvariants-detail:variant_uid$
+
+        __Response__:
+
+            STATUS: 204 NO CONTENT
+
+        __Example__:
+
+            curl -X DELETE -H "Content-Type: application/json" $URL:unreleasedvariants-detail:variant_uid$
+        """
+        return super(UnreleasedVariantViewSet, self).destroy(request, **kwargs)
+
+    def update(self, request, *args, **kwargs):
+        """
+        __Method__:
+        PUT/PATCH
+
+        __URL__: $LINK:unreleasedvariants-detail:variant_uid$
+
+        __Data__:
+
+        %(WRITABLE_SERIALIZER)s
+
+        __Response__:
+
+        %(SERIALIZER)s
+
+        __Example__:
+
+            curl -X PATCH -d '{ "active": true}' -H "Content-Type: application/json" \\
+                $URL:unreleasedvariants-detail:testmodule-master-20170301215520$
+        """
+        return super(UnreleasedVariantViewSet, self).update(request, *args, **kwargs)

--- a/pdc/settings_common.py
+++ b/pdc/settings_common.py
@@ -98,6 +98,7 @@ INSTALLED_APPS = (
     'pdc.apps.usage',
     'pdc.apps.osbs',
     'pdc.apps.componentbranch',
+    'pdc.apps.unreleasedvariant',
 
     'mptt',
 )


### PR DESCRIPTION
Add v2 of the "unreleasedvariants" API called "module" and correct the docs in "unreleasedvariants"

To use v1 of the API, continue using the "unreleasedvariants" API but for v2, use the "module" API.

The new version of the API does the following:
* Renames "variant_name" to "name"
* Renames "variant_version" to "stream"
* Renames "variant_release" to "version"
* Renames "variant_context" to "context"
* Renames "variant_uid" to "uid"
* Drops the usage of "variant_type" (now set to "module" in the DB)
* Drops the usage of "variant_id" (now set to the module name in the DB)
* "uid" is now read-only and the value is derived as "name:stream:version:context"