### PR TITLE
Replace kobo-rpm dependency with own functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,12 @@ addons:
             - swig
             - libldap2-dev
             - graphviz
-# The sed command is a terrible hack: we can't easily install koji on Ubuntu.
-# PDC does not need it, it is a dependency of kobo. However, PDC does not use
-# any part of kobo that would actively use koji, se we just delete the
-# offending import.
 install:
     - git config --global user.name  "Travis CI"
     - git config --global user.email "pdc@product-definition-center.com"
     - export REPO_URL_GITHUB="https://$GH_TOKEN@github.com/$GH_REPO.git"
     - pip install -U pip wheel coveralls
     - pip install -r requirements/devel.txt
-    - sed -i -E '/import (koji|rpm)/d' $(python -vc 'import kobo.rpmlib' 2>&1 | grep 'import kobo.rpmlib' | awk '{print$NF}' | sed 's/pyc$/py/')
 script:
     - coverage run --source=contrib,pdc --omit='*tests.py,*/migrations/*,pdc/settings*' manage.py test --settings pdc.settings_test contrib pdc
     - make flake8

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,6 @@ RUN dnf -y upgrade && \
         swig \
         openldap-devel \
         krb5-devel \
-        koji \
         patternfly1 \
         vim-enhanced \
         'graphviz*' \

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -28,9 +28,7 @@ For development purposes, install following dependencies:
 * python-requests-kerberos
 * python-mock
 * kobo >= 0.4.2
-* kobo-rpmlib
 * kobo-django
-* koji
 * djangorestframework>=3.1
 * django-mptt >= 0.7.1
 * Markdown
@@ -47,21 +45,14 @@ For development purposes, install following dependencies:
 Option 2: Start it on virtualenv
 ````````````````````````````````
 
-* Koji is not available on PyPI. You must install the `koji` package to your
-  system via ``yum`` before creating a virtualenv. ::
-
-    $ sudo yum install koji
-
-* After that, run ::
+* Install virtualenvwrapper ::
 
     $ pip install virtualenvwrapper
 
   and setup according to 'Setup' steps in ``/usr/bin/virtualenvwrapper.sh``.
-  Then run ::
+  Then create virtual environment ::
 
-    $ mkvirtualenv pdc --system-site-packages
-
-  to include `koji` into your *pdc* virtualenv.
+    $ mkvirtualenv pdc
 
 * Run the following ::
 

--- a/pdc.spec
+++ b/pdc.spec
@@ -19,8 +19,6 @@ Requires:       django-rest-framework < 3.3
 Requires:       django-mptt >= 0.7.1
 Requires:       kobo >= 0.4.2
 Requires:       kobo-django
-Requires:       kobo-rpmlib
-Requires:       koji
 Requires:       patternfly1 == 1.3.0
 Requires:       productmd >= 1.1
 Requires:       python-django-filter >= 0.9.2

--- a/pdc/apps/compose/filters.py
+++ b/pdc/apps/compose/filters.py
@@ -3,7 +3,7 @@
 # Licensed under The MIT License (MIT)
 # http://opensource.org/licenses/MIT
 #
-import kobo.rpmlib
+from pdc.apps.utils.rpm import parse_nvr, parse_nvra
 
 import django_filters
 from django.db.models import Q
@@ -30,7 +30,7 @@ class ComposeFilter(django_filters.FilterSet):
     @value_is_not_empty
     def filter_nvr(self, qs, value):
         try:
-            nvr = kobo.rpmlib.parse_nvr(value)
+            nvr = parse_nvr(value)
         except ValueError:
             raise ValidationError("Invalid NVR: %s" % value)
 
@@ -43,7 +43,7 @@ class ComposeFilter(django_filters.FilterSet):
     @value_is_not_empty
     def filter_nvra(self, qs, value):
         try:
-            nvra = kobo.rpmlib.parse_nvra(value)
+            nvra = parse_nvra(value)
         except ValueError:
             raise ValidationError("Invalid NVRA: %s" % value)
 

--- a/pdc/apps/compose/lib.py
+++ b/pdc/apps/compose/lib.py
@@ -8,7 +8,6 @@
 import os
 import json
 
-import kobo
 import productmd
 from productmd.rpms import Rpms
 
@@ -28,6 +27,7 @@ from pdc.apps.compose.serializers import ComposeTreeSerializer
 from pdc.apps.release.models import Release
 from pdc.apps.component.models import ReleaseComponent
 from pdc.apps.repository.models import ContentCategory
+from pdc.apps.utils.rpm import parse_nvr
 
 
 def _maybe_raise_inconsistency_error(composeinfo, manifest, name):
@@ -367,7 +367,7 @@ def _find_composes_srpm_name_with_rpm_nvr(nvr):
     Filter composes and SRPM's name with rpm nvr
     """
     try:
-        nvr = kobo.rpmlib.parse_nvr(nvr)
+        nvr = parse_nvr(nvr)
     except ValueError:
         raise ValueError("Invalid NVR: %s" % nvr)
     q = Q()

--- a/pdc/apps/package/models.py
+++ b/pdc/apps/package/models.py
@@ -15,7 +15,6 @@ from django.dispatch import receiver
 from django.db.backends.signals import connection_created
 from django.db.models.signals import post_migrate
 
-from kobo.rpmlib import parse_nvra
 from productmd import images
 
 from pdc.apps.common.models import get_cached_id
@@ -26,6 +25,7 @@ from pdc.apps.release.models import Release
 from pdc.apps.compose.models import ComposeAcceptanceTestingState
 from pdc.apps.package.apps import PackageConfig
 from pdc.apps.repository.models import Repo
+from pdc.apps.utils.rpm import parse_nvra
 from django.utils import timezone
 
 

--- a/pdc/apps/utils/rpm.py
+++ b/pdc/apps/utils/rpm.py
@@ -1,0 +1,94 @@
+#
+# Copyright (c) 2018 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#
+import re
+
+_RE_PATTERNS = {
+    'name': r'(?P<name>[^:]+)',
+    'version': r'(?P<version>[^:]+)',
+    'release': r'(?P<release>[^:]+)',
+    'epoch': r'(?P<epoch>[0-9]+)',
+    'arch': r'(?P<arch>[^:.-]+)',
+}
+
+
+def _compile_re(nvr_format):
+    pattern = nvr_format.replace('.', '\\.')
+    return re.compile((r'^(?:.*/)?' + pattern + r'$').format(**_RE_PATTERNS))
+
+
+_RE_NVRE = _compile_re('{name}-{version}-{release}:{epoch}')
+_RE_ENVR = _compile_re('{epoch}:{name}-{version}-{release}')
+_RE_NEVR = _compile_re('{name}-{epoch}:{version}-{release}')
+_RE_NVR = _compile_re('{name}-{version}-{release}')
+
+_RE_NVREA = _compile_re('{name}-{version}-{release}:{epoch}.{arch}')
+_RE_ENVRA = _compile_re('{epoch}:{name}-{version}-{release}.{arch}')
+_RE_NEVRA = _compile_re('{name}-{epoch}:{version}-{release}.{arch}')
+_RE_NVRAE = _compile_re('{name}-{version}-{release}.{arch}:{epoch}')
+_RE_NVRA = _compile_re('{name}-{version}-{release}.{arch}')
+
+_RE_NVREA_RPM = _compile_re('{name}-{version}-{release}:{epoch}.{arch}.rpm')
+_RE_ENVRA_RPM = _compile_re('{epoch}:{name}-{version}-{release}.{arch}.rpm')
+_RE_NEVRA_RPM = _compile_re('{name}-{epoch}:{version}-{release}.{arch}.rpm')
+_RE_NVRAE_RPM = _compile_re('{name}-{version}-{release}.{arch}.rpm:{epoch}')
+_RE_NVRAE_RPM2 = _compile_re('{name}-{version}-{release}.{arch}:{epoch}.rpm')
+_RE_NVRA_RPM = _compile_re('{name}-{version}-{release}.{arch}.rpm')
+
+_RE_LIST_NVRE = [_RE_NVRE, _RE_ENVR, _RE_NEVR]
+_RE_LIST_NVR = [_RE_NVR]
+
+_RE_LIST_NVRAE = [
+    _RE_NVREA_RPM, _RE_ENVRA_RPM, _RE_NEVRA_RPM, _RE_NVRAE_RPM, _RE_NVRAE_RPM2,
+    _RE_NVREA, _RE_ENVRA, _RE_NEVRA, _RE_NVRAE]
+
+_RE_LIST_NVRA = [_RE_NVRA_RPM, _RE_NVRA]
+
+
+def _match_first_or_none(what, regexes):
+    for regex in regexes:
+        result = regex.match(what)
+        if result:
+            return result.groupdict()
+
+    return None
+
+
+def _match_first(nvr_type, what, regexes_with_epoch, regexes_without_epoch):
+    result = _match_first_or_none(what, regexes_with_epoch)
+    if result:
+        return result
+
+    result = _match_first_or_none(what, regexes_without_epoch)
+    if not result:
+        raise ValueError("Invalid %s: %s" % (nvr_type, what))
+
+    result['epoch'] = ''
+    return result
+
+
+def parse_nvr(nvre):
+    """
+    Split N-V-R into a dictionary.
+
+    @param nvre: N-V-R[:E], E:N-V-R or N-E:V-R string
+    @type nvre: str
+    @return: {name, version, release, epoch}
+    @rtype: dict
+    """
+    return _match_first('NVRE', nvre, _RE_LIST_NVRE, _RE_LIST_NVR)
+
+
+def parse_nvra(nvra):
+    """Split N-V-R.A[.rpm] into a dictionary.
+
+    @param nvra: N-V-R[:E].A[.rpm], E:N-V-R.A[.rpm], N-V-R.A[.rpm]:E or N-E:V-R.A[.rpm] string
+    @type nvra: str
+    @return: {name, version, release, epoch, arch, src}
+    @rtype: dict
+    """
+    result = _match_first('NVRA', nvra, _RE_LIST_NVRAE, _RE_LIST_NVRA)
+    result['src'] = (result['arch'] == 'src')
+    return result


### PR DESCRIPTION
Package kobo-rpm requires rpm to be installed on system. This can be
problem for some distributions like Ubuntu which is used by Travis CI.

As solution, parse_nvr() and parse_nvra() are implemented in PDC. The
new functions use regular expressions constructed from simple formatted
strings.

Tests are taken from kobo. There are few additional ones so that every
regular expression matches at least once.