### PR TITLE
Fix displaying deleted composes

### DIFF
--- a/pdc/apps/compose/views.py
+++ b/pdc/apps/compose/views.py
@@ -1526,7 +1526,7 @@ class FindComposeMixin(object):
 
     def _get_composes_for_release(self):
         result = []
-        composes = Compose.objects.filter(release__release_id=self.release_id)
+        composes = Compose.objects.filter(release__release_id=self.release_id, deleted=False)
         composes = self._filter_by_compose_type(composes)
         result = self._get_result(composes, result)
         return result
@@ -1536,7 +1536,7 @@ class FindComposeMixin(object):
         all_composes = []
         releases = Release.objects.filter(product_version__product_version_id=self.product_version)
         for release in releases:
-            composes = Compose.objects.filter(release=release)
+            composes = Compose.objects.filter(release=release, deleted=False)
             composes = self._filter_by_compose_type(composes)
             all_composes.extend(composes)
         result = self._get_result(all_composes, result)
@@ -1580,6 +1580,7 @@ class FindComposeMixin(object):
         current_rpms = set(r.sort_key for r in compose.get_rpms(self.rpm_name))
         # Find older composes for same release (not including this one)
         composes = (Compose.objects
+                    .exclude(deleted=True)
                     # Get only older composes
                     .exclude(compose_date__gt=compose.compose_date)
                     # Only composes in the same product

--- a/pdc/apps/release/models.py
+++ b/pdc/apps/release/models.py
@@ -278,7 +278,7 @@ class Release(AllowedPushTargetsModel):
         """
         Return a set of all composes built for this release or linked to it.
         """
-        return set(self.compose_set.all()) | set(self.linked_composes.all())
+        return set(self.compose_set.filter(deleted=False)) | set(self.linked_composes.filter(deleted=False))
 
     def get_latest_compose(self):
         """


### PR DESCRIPTION
When a compose is marked as deleted, it should not show up by default in some places. The compose list has a filter, so there it's ok.

This patch fixes and tests that compose_set in /releases/ API does not include deleted composes (either directly connected or linked).

Also the lower level method used to get latest compose for a release is tested to not include deleted ones. This should fix RPM Mapping API end-point.

The APIs to get compose by release or product version and RPM NVR are updated to not return deleted composes.

JIRA: PDC-2533