### PR TITLE
Fix access to modules with dot in UID

### DIFF
--- a/pdc/apps/common/viewsets.py
+++ b/pdc/apps/common/viewsets.py
@@ -248,7 +248,11 @@ class PDCModelViewSet(StrictQueryParamMixin,
     PDC common ModelViewSet.
     With `StrictQueryParam`, `ProtectOnDelete` and `ChangeSetModel`
     """
-    pass
+
+    # The field used in URL can not contain a . character by default. This
+    # attribute changes that so that we can use anything in URL as long as
+    # there is no slash.
+    lookup_value_regex = r'[^/]+'
 
 
 class MultiLookupFieldMixin(object):

--- a/pdc/apps/module/tests.py
+++ b/pdc/apps/module/tests.py
@@ -264,6 +264,12 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
         # Make sure the old UID isn't in the database anymore
         self.assertEqual(Module.objects.filter(uid=old_uid).count(), 0)
 
+    def test_get_module_with_dot_in_uid(self):
+        self.create_module(version='1.2')
+        url = reverse('modules-detail', args=['testmodule:f27:1.2:12345678'])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     def test_get_modules(self):
         self.create_module(version='23456789', active=True)
         self.create_module(version='89012345', active=False)

--- a/pdc/apps/unreleasedvariant/tests.py
+++ b/pdc/apps/unreleasedvariant/tests.py
@@ -296,6 +296,20 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
         uv = Module.objects.filter(uid='coretest123').first()
         self.assertEqual(uv.context, 'a23d56a8')
 
+    def test_unreleasedvariant_with_dot_in_uid(self):
+        url = reverse('unreleasedvariants-list')
+        data = {
+            'variant_id': "core", 'variant_uid': "coretest1.23",
+            'variant_name': "Core", 'variant_version': "1.23",
+            'variant_release': "1", 'variant_type': 'module',
+            'variant_context': 'a23d56a8', 'koji_tag': "module-core-0-1",
+            'modulemd': 'foobar'
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        response = self.client.get(reverse('unreleasedvariants-detail', args=['coretest1.23']))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     def test_v2_compatibility_unreleasedvariant(self):
         data = {
             'name': 'testmodule',


### PR DESCRIPTION
The default router will not allow the field in URL to contain a dot: it fails to create the URL in that case. This patch sets a regex so that the UID can be anything without a slash.

JIRA: PDC-2535