### PR TITLE
Filter modules by RPM filename

### DIFF
--- a/pdc/apps/module/filters.py
+++ b/pdc/apps/module/filters.py
@@ -19,6 +19,7 @@ class ModuleFilterBase(django_filters.FilterSet):
     build_dep_stream    = MultiValueFilter(name='build_deps__stream', distinct=True)
     component_name      = MultiValueFilter(name='rpms__srpm_name', distinct=True)
     component_branch    = MultiValueFilter(name='rpms__srpm_commit_branch', distinct=True)
+    rpm_filename        = MultiValueFilter(name='rpms__filename', distinct=True)
 
 
 class ModuleFilter(ModuleFilterBase):

--- a/pdc/apps/module/tests.py
+++ b/pdc/apps/module/tests.py
@@ -142,6 +142,16 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
         response_seven = self.client.get(url, data={'component_name': 'python'}, format='json')
         self.assertEqual(response_seven.data['count'], 0)
 
+        # Filtering by RPM filename
+        response_eight = self.client.get(url,
+                                         data={'rpm_filename': 'foobar-2.0.0-1.src.rpm'},
+                                         format='json')
+        self.assertEqual(response_eight.data['count'], 1)
+        response_nine = self.client.get(url,
+                                        data={'rpm_filename': 'python-2.7.12-1.el7.noarch.rpm'},
+                                        format='json')
+        self.assertEqual(response_nine.data['count'], 0)
+
     def test_create_and_get_module_with_exist_rpms(self):
         url = reverse('modules-list')
         self.data['rpms'] = [{

--- a/pdc/apps/unreleasedvariant/tests.py
+++ b/pdc/apps/unreleasedvariant/tests.py
@@ -217,6 +217,16 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertNotIn("Core", [x['variant_uid'] for x in response.data['results']])
         self.assertIn("Core2", [x['variant_uid'] for x in response.data['results']])
 
+        # Filtering by RPM filename
+        response = self.client.get(url,
+                                   data={'rpm_filename': 'foobar-2.0.0-1.src.rpm'},
+                                   ormat='json')
+        self.assertEqual(response.data['count'], 1)
+        response = self.client.get(url,
+                                   data={'rpm_filename': 'python-2.7.12-1.el7.noarch.rpm'},
+                                   format='json')
+        self.assertEqual(response.data['count'], 0)
+
     def test_create_with_exist_rpms(self):
         url = reverse('unreleasedvariants-list')
         data = {


### PR DESCRIPTION
Due to how the new API works, the same filter can be added to unreleased variants for free. Tests are added in both APIs.

JIRA: PDC-2382