### PR TITLE
Dummy messenger should log the messages

### DIFF
--- a/pdc/apps/compose/lib.py
+++ b/pdc/apps/compose/lib.py
@@ -86,7 +86,7 @@ def _add_compose_create_msg(request, compose_obj):
            'compose_date': compose_obj.compose_date.isoformat(),
            'compose_type': compose_obj.compose_type.name,
            'compose_respin': compose_obj.compose_respin}
-    request._request._messagings.append(('.compose', json.dumps(msg)))
+    request._request._messagings.append(('.compose', msg))
 
 
 def _add_import_msg(request, compose_obj, attribute, count):
@@ -103,7 +103,7 @@ def _add_import_msg(request, compose_obj, attribute, count):
            'compose_date': compose_obj.compose_date.isoformat(),
            'compose_type': compose_obj.compose_type.name,
            'compose_respin': compose_obj.compose_respin}
-    request._request._messagings.append(('.' + attribute, json.dumps(msg)))
+    request._request._messagings.append(('.' + attribute, msg))
 
 
 def _store_relative_path_for_compose(compose_obj, variants_info, variant, variant_obj, add_to_changelog):

--- a/pdc/apps/compose/tests.py
+++ b/pdc/apps/compose/tests.py
@@ -778,11 +778,10 @@ class ComposeUpdateMessagingTestCase(APITestCase):
 
             topic, msg = messages[0]
             self.assertEqual(topic, '.compose')
-            data = json.loads(msg)
-            self.assertEqual(data['action'], 'update')
-            self.assertEqual(data['compose_id'], 'compose-1')
-            self.assertEqual(data['to']['acceptance_testing'], 'passed')
-            self.assertEqual(data['from']['acceptance_testing'], 'untested')
+            self.assertEqual(msg['action'], 'update')
+            self.assertEqual(msg['compose_id'], 'compose-1')
+            self.assertEqual(msg['to']['acceptance_testing'], 'passed')
+            self.assertEqual(msg['from']['acceptance_testing'], 'untested')
 
 
 class OverridesRPMAPITestCase(TestCaseWithChangeSetMixin, APITestCase):

--- a/pdc/apps/compose/views.py
+++ b/pdc/apps/compose/views.py
@@ -643,10 +643,10 @@ class ComposeViewSet(StrictQueryParamMixin,
                                   json.dumps({'linked_releases': old_data['linked_releases']}),
                                   json.dumps({'linked_releases': response.data['linked_releases']}))
             # Add message
-            self._add_messaging_info(request, json.dumps({'action': 'update',
-                                                          'compose_id': self.object.compose_id,
-                                                          'from': old_data,
-                                                          'to': response.data}))
+            self._add_messaging_info(request, {'action': 'update',
+                                               'compose_id': self.object.compose_id,
+                                               'from': old_data,
+                                               'to': response.data})
         return response
 
     def perform_update(self, serializer):

--- a/pdc/apps/utils/messaging.py
+++ b/pdc/apps/utils/messaging.py
@@ -13,11 +13,9 @@ logger = logging.getLogger(__name__)
 
 
 class DummyMessenger(object):
-    def __init__(self):
-        pass
 
     def send_message(self, topic, msg):
-        pass
+        logger.info('Sending to %s:\n%s' % (topic, json.dumps(msg, sort_keys=True, indent=2)))
 
 
 class KombuMessenger(object):


### PR DESCRIPTION
Instead of ignoring them all, it should log them. This can be easily disabled in the LOGGING settings by adding following snippet:

    'pdc.apps.utils.messaging': {
        'level': 'WARNING',
    }

JIRA: PDC-2583