### PR TITLE
Fix search forms for base product and product version

### DIFF
--- a/pdc/apps/release/forms.py
+++ b/pdc/apps/release/forms.py
@@ -28,8 +28,6 @@ class ReleaseSearchForm(forms.Form):
             query |= Q(name__icontains=search)
             query |= Q(release_id__icontains=search)
 
-        # TODO: disabled
-
         return query
 
 
@@ -46,8 +44,6 @@ class BaseProductSearchForm(forms.Form):
             query |= Q(name__icontains=search)
             query |= Q(base_product_id__icontains=search)
             query |= Q(release_type__short__icontains=search)
-
-        # TODO: disabled
 
         return query
 

--- a/pdc/apps/release/forms.py
+++ b/pdc/apps/release/forms.py
@@ -79,7 +79,6 @@ class ProductVersionSearchForm(forms.Form):
 
         if search:
             query |= Q(name__icontains=search)
-            query |= Q(short__icontains=search)
-            query |= Q(version__icontains=search)
+            query |= Q(product_version_id__icontains=search)
 
         return query

--- a/pdc/apps/release/forms.py
+++ b/pdc/apps/release/forms.py
@@ -43,9 +43,9 @@ class BaseProductSearchForm(forms.Form):
         query = Q()
 
         if search:
-            query |= Q(short__icontains=search)
-            query |= Q(version__icontains=search)
             query |= Q(name__icontains=search)
+            query |= Q(base_product_id__icontains=search)
+            query |= Q(release_type__short__icontains=search)
 
         # TODO: disabled
 


### PR DESCRIPTION
They should search in the full ID. Since it contains short and version, we can remove those two fields.

PDC-2478