### PR TITLE
Improve documentation for rpms field

### DIFF
--- a/pdc/apps/module/serializers.py
+++ b/pdc/apps/module/serializers.py
@@ -13,7 +13,7 @@ from pdc.apps.package.models import RPM
 
 # Inherit from this class so we can override the documentation variables
 class RPMModuleField(RPMRelatedField):
-    doc_format = '"string"'
+    doc_format = '"string (format: NEVRA.rpm)"'
     writable_doc_format = ('{"name": "string", "epoch": "string", "version": "string", '
                            '"release": "string", "arch": "string", "srpm_name": "string"}')
 

--- a/pdc/apps/module/serializers.py
+++ b/pdc/apps/module/serializers.py
@@ -14,8 +14,10 @@ from pdc.apps.package.models import RPM
 # Inherit from this class so we can override the documentation variables
 class RPMModuleField(RPMRelatedField):
     doc_format = '"string (format: NEVRA.rpm)"'
-    writable_doc_format = ('{"name": "string", "epoch": "string", "version": "string", '
-                           '"release": "string", "arch": "string", "srpm_name": "string"}')
+    writable_doc_format = (
+        '{"name": "string", "epoch": "string", "version": "string", '
+        '"release": "string", "arch": "string", "srpm_name": "string", '
+        '"srpm_nevra": "string (only required and allowed for non-src RPMs)"}')
 
 
 class RuntimeDepSerializer(serializers.ModelSerializer):

--- a/pdc/apps/package/views.py
+++ b/pdc/apps/package/views.py
@@ -279,7 +279,7 @@ class BuildImageViewSet(pdc_viewsets.PDCModelViewSet):
                     "image_format":       string,
                     "md5":                string,
                     "rpms": [
-                        "rpm_nevra",      string,
+                        "rpm_nevra.rpm",  string,
                         ...
                     ],
                     "archives": [


### PR DESCRIPTION
This applies to modules and build-images API.
* Explictly say that the value is NEVRA with `.rpm` suffix
* Mention that `srpm_nevra` is required when creating modules.