### PR TITLE
Document options for Dist-Git urls

### DIFF
--- a/pdc/settings_common.py
+++ b/pdc/settings_common.py
@@ -240,9 +240,13 @@ REST_API_MAX_PAGE_SIZE = 100
 
 API_HELP_TEMPLATE = "api/help.html"
 
-DIST_GIT_WEB_ROOT_URL = "http://pkgs.example.com/cgit/"
-DIST_GIT_RPM_PATH = 'rpms/'
-DIST_GIT_REPO_FORMAT = DIST_GIT_WEB_ROOT_URL + DIST_GIT_RPM_PATH + "%s"
+# Format string used for URLs in global and release components pointing to
+# Dist-Git server. One value will be substituted into this format string: the
+# name of the package.
+DIST_GIT_REPO_FORMAT = "http://pkgs.example.com/cgit/rpms/%s"
+# URL fragment used to point to a particular branch of a package on Dist-Git.
+# This will be appended to the URL created with DIST_GIT_REPO_FORMAT.
+# The default works for CGit.
 DIST_GIT_BRANCH_FORMAT = "?h=%s"
 
 # ldap settings


### PR DESCRIPTION
The default config file now has comments explaining what the options actually do.

DIST_GIT_WEB_ROOT and DIST_GIT_RPMS_PATH options are no longer mentioned. They were not used anywhere else but to construct DIST_GIT_REPO_FORMAT, which is the only option really used in code.

This is backwards compatible change: users are still free to define as many helper variables as they want, but the defaults are no longer misleading people to change only the helpers without having any effect.

JIRA: PDC-2451