### PR TITLE
Send messages from RPMRelated field

### DIFF
--- a/pdc/apps/common/tests.py
+++ b/pdc/apps/common/tests.py
@@ -711,11 +711,11 @@ class NotificationMixinTestCase(TestCase):
         }
         self.view = DummyView.as_view(mapping, basename='dummy')
 
-    def _make_request(self, method, data=None, comment=None):
+    def _make_request(self, method, data=None):
         request = django.http.HttpRequest()
         request.method = method
         request._messagings = []
-        request.META = {'HTTP_PDC_CHANGE_COMMENT': comment, 'SERVER_NAME': '0.0.0.0', 'SERVER_PORT': 80}
+        request.META = {'SERVER_NAME': '0.0.0.0', 'SERVER_PORT': 80}
         if data:
             data = json.dumps(data)
             request._read_started = False
@@ -726,8 +726,7 @@ class NotificationMixinTestCase(TestCase):
     @mock.patch('pdc.apps.common.viewsets.router')
     @mock.patch('pdc.apps.common.viewsets.reverse')
     def test_create_notification(self, mock_reverse, mock_router):
-        request = self._make_request('POST', {'nickname': 'Rover', 'color': 'brown'},
-                                     comment='Sit!')
+        request = self._make_request('POST', {'nickname': 'Rover', 'color': 'brown'})
         mock_reverse.return_value = '/dogs/2/'
         mock_router.registry = [('dogs', None, 'dummy')]
 
@@ -741,8 +740,6 @@ class NotificationMixinTestCase(TestCase):
                                  'color': 'brown',
                                  'nickname': 'Rover'
                              },
-                             'author': '',
-                             'comment': 'Sit!',
                          })])
         self.assertEqual(mock_reverse.call_args_list,
                          [mock.call('dummy-detail', args=[2])])
@@ -768,15 +765,13 @@ class NotificationMixinTestCase(TestCase):
                                  'color': 'black',
                                  'nickname': 'Spot'
                              },
-                             'author': '',
-                             'comment': None,
                          })])
         self.assertEqual(mock_reverse.call_args_list,
                          [mock.call('dummy-detail', args=[1])])
 
     @mock.patch('pdc.apps.common.viewsets.router')
     def test_delete_notification(self, mock_router):
-        request = self._make_request('DELETE', comment='Go')
+        request = self._make_request('DELETE')
         mock_router.registry = [('dogs', None, 'dummy')]
 
         response = self.view(request, pk=1)
@@ -789,6 +784,4 @@ class NotificationMixinTestCase(TestCase):
                                  'color': 'black',
                                  'nickname': 'Spot'
                              },
-                             'author': '',
-                             'comment': 'Go',
                          })])

--- a/pdc/apps/common/viewsets.py
+++ b/pdc/apps/common/viewsets.py
@@ -115,11 +115,7 @@ class NotificationMixin(object):
             # viewset.
             raise RuntimeError('Viewset %r not exposed in router.' % self)
         topic = '.%s.%s' % (resource, action)
-        msg.update({
-            'url': self._get_url(obj) if obj else None,
-            'author': self.request.user.username,
-            'comment': self.request.META.get("HTTP_PDC_CHANGE_COMMENT", None),
-        })
+        msg['url'] = self._get_url(obj) if obj else None
 
         self.request._request._messagings.append((topic, msg))
 

--- a/pdc/apps/package/serializers.py
+++ b/pdc/apps/package/serializers.py
@@ -7,6 +7,7 @@ import json
 
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import serializers
+from rest_framework.reverse import reverse
 
 from . import models
 from pdc.apps.compose.models import ComposeAcceptanceTestingState
@@ -139,6 +140,16 @@ class RPMRelatedField(serializers.RelatedField):
                                               rpm.id,
                                               'null',
                                               json.dumps(rpm.export()))
+
+                    if request and hasattr(request, '_messagings'):
+                        msg = {
+                            'url': reverse('rpms-detail', args=[rpm.pk], request=request),
+                            'author': request.user.username,
+                            'comment': request.META.get("HTTP_PDC_CHANGE_COMMENT", None),
+                            'new_value': serializer.data,
+                        }
+                        request._messagings.append(('.rpms.added', msg))
+
                     return rpm
                 else:
                     raise serializers.ValidationError(serializer.errors)

--- a/pdc/apps/package/serializers.py
+++ b/pdc/apps/package/serializers.py
@@ -142,8 +142,6 @@ def _announce_new_object(request, obj, route, topic, data):
     if request and hasattr(request, '_messagings'):
         msg = {
             'url': reverse(route, args=[obj.pk], request=request),
-            'author': request.user.username,
-            'comment': request.META.get("HTTP_PDC_CHANGE_COMMENT", None),
             'new_value': data,
         }
         request._messagings.append(('.%s.added' % topic, msg))

--- a/pdc/apps/package/tests.py
+++ b/pdc/apps/package/tests.py
@@ -1581,7 +1581,6 @@ class BuildImageRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertIn('version', response.content)
         self.assertIn('release', response.content)
         self.assertIn('arch', response.content)
-        self.assertIn('srpm_name', response.content)
 
     def test_create_with_new_rpms_missing_fields(self):
         url = reverse('buildimage-list')
@@ -1597,6 +1596,18 @@ class BuildImageRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertIn('version', response.content)
         self.assertIn('release', response.content)
         self.assertIn('arch', response.content)
+
+    def test_create_with_new_rpms_missing_non_unique_fields(self):
+        url = reverse('buildimage-list')
+        data = {'image_id': 'new_build',
+                'image_format': 'docker',
+                'md5': "0123456789abcdef0123456789abcdef",
+                'rpms': [{'name': 'new_rpm', 'epoch': 0, 'version': '1.0',
+                          'release': '1', 'arch': 'x86_64'}],
+                'archives': []}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('rpms', response.content)
         self.assertIn('srpm_name', response.content)
 
     def test_create_with_exist_archives_missing_fields(self):
@@ -1612,7 +1623,6 @@ class BuildImageRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertIn('archives', response.content)
         self.assertIn('name', response.content)
         self.assertIn('size', response.content)
-        self.assertIn('md5', response.content)
 
     def test_create_with_new_archives_missing_fields(self):
         url = reverse('buildimage-list')
@@ -1627,6 +1637,18 @@ class BuildImageRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertIn('archives', response.content)
         self.assertIn('name', response.content)
         self.assertIn('size', response.content)
+
+    def test_create_with_new_archives_missing_non_unique_field(self):
+        url = reverse('buildimage-list')
+        data = {'image_id': 'new_build',
+                'image_format': 'docker',
+                'md5': "0123456789abcdef0123456789abcdef",
+                'rpms': [],
+                'archives': [{'build_nvr': 'new_build', 'name': 'foo', 'size': 125}]
+                }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('archives', response.content)
         self.assertIn('md5', response.content)
 
     def test_get(self):

--- a/pdc/apps/utils/middleware.py
+++ b/pdc/apps/utils/middleware.py
@@ -28,12 +28,15 @@ class MessagingMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         if not getattr(response, 'exception', 0) and response.status_code < 400:
             if hasattr(request, '_messagings'):
-                extra_fields = {}
+                extra_fields = {
+                    'author': request.user.username,
+                    'comment': request.META.get("HTTP_PDC_CHANGE_COMMENT", None),
+                }
                 if hasattr(request, 'changeset') and request.changeset.pk:
-                    extra_fields = {
+                    extra_fields.update({
                         'changeset_id': request.changeset.pk,
                         'committed_on': str(request.changeset.committed_on),
-                    }
+                    })
                 for topic, msg in request._messagings:
                     msg.update(extra_fields)
                     messenger.send_message(topic=topic, msg=msg)


### PR DESCRIPTION
When it creates a new object in database, it should publish a message about it.

Both use cases are updated to test that the message was actually sent.

JIRA: PDC-2603