### PR TITLE
WIP: Make lookup fields immutable

### DIFF
--- a/pdc/apps/common/tests.py
+++ b/pdc/apps/common/tests.py
@@ -368,16 +368,14 @@ class SigKeyRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['name'], 'TEST')
 
-    def test_can_update_key_id(self):
+    def test_update_key_id_fails(self):
         response = self.client.patch(reverse('sigkey-detail', args=['1234adbf']),
                                      {'key_id': 'cafebabe'},
                                      format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data.get('key_id'), 'cafebabe')
-        self.assertNumChanges([1])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, {'key_id': 'Immutable field cannot be updated'})
+        self.assertNumChanges([])
         response = self.client.get(reverse('sigkey-detail', args=['1234adbf']))
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        response = self.client.get(reverse('sigkey-detail', args=['cafebabe']))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_can_bulk_update(self):

--- a/pdc/apps/contact/tests.py
+++ b/pdc/apps/contact/tests.py
@@ -70,14 +70,14 @@ class ContactRoleRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('results')[0].get('name'), 'qe_ack')
 
-    def test_update(self):
+    def test_update_name_fails(self):
         url = reverse('contactrole-detail', args=['qe_ack'])
         data = {'name': 'new_role'}
         response = self.client.put(url, data, format='json')
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data.get('name'), 'new_role')
-        self.assertNumChanges([1])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, {'name': 'Immutable field cannot be updated'})
+        self.assertNumChanges([])
 
     def test_delete(self):
         url = reverse('contactrole-detail', args=['qe_ack'])
@@ -126,7 +126,7 @@ class ContactRoleRESTTestCase(TestCaseWithChangeSetMixin, APITestCase):
 
     def test_update_missing_optional_fields_are_erased(self):
         response = self.client.put(reverse('contactrole-detail', args=['allow_3_role']),
-                                   {'name': 'new_name'}, format='json')
+                                   {'name': 'allow_3_role'}, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count_limit'], 1)
         self.assertNumChanges([1])


### PR DESCRIPTION
Tries to make sure that URL of an object doesn't after an PUT or PATCH
by disallowing changing the lookup fields which are part of URL.

Drawbacks:

- PUT requests still need to contain the lookup field with original
value
- Can break existing scripts

JIRA: PDC-2339

---

Not sure about this at all. Probably better to just implement the new immutable numeric IDs.