### PR TITLE
Add filter for modules for RPM name and branch

### DIFF
--- a/pdc/apps/module/filters.py
+++ b/pdc/apps/module/filters.py
@@ -6,8 +6,28 @@
 
 import django_filters
 
-from pdc.apps.common.filters import CaseInsensitiveBooleanFilter, MultiValueFilter
+from pdc.apps.common.filters import CaseInsensitiveBooleanFilter, MultiValueFilter, value_is_not_empty
 from pdc.apps.module.models import Module
+from pdc.apps.package.models import RPM
+
+
+class ModuleComponentFilter(MultiValueFilter):
+    """
+    Multi-value filter for modules with an RPM with given name and branch.
+    """
+    @value_is_not_empty
+    def _filter(self, qs, name, values):
+        for value in values:
+            try:
+                name, branch = value.split('/', 2)
+                filters = {'name': name, 'srpm_commit_branch': branch}
+            except ValueError:
+                filters = {'name': value}
+
+            rpms = RPM.objects.filter(**filters)
+            qs = qs.filter(rpms__in=rpms)
+
+        return qs
 
 
 class ModuleFilterBase(django_filters.FilterSet):
@@ -18,7 +38,17 @@ class ModuleFilterBase(django_filters.FilterSet):
     build_dep_name      = MultiValueFilter(name='build_deps__dependency', distinct=True)
     build_dep_stream    = MultiValueFilter(name='build_deps__stream', distinct=True)
     component_name      = MultiValueFilter(name='rpms__srpm_name', distinct=True)
-    component_branch    = MultiValueFilter(name='rpms__srpm_commit_branch', distinct=True)
+    component_branch    = MultiValueFilter(
+        name='rpms__srpm_commit_branch', distinct=True,
+        help_text="""
+        Note that "component_name" filter can match different component than this filter.
+        Use "component" filter instead to match both name and branch in a single component.
+        """)
+    component           = ModuleComponentFilter(
+        help_text="""
+        Match name and branch in a single component.
+        Format is "<component_name>/<component_branch>" or just "<component_name>".
+        """)
     rpm_filename        = MultiValueFilter(name='rpms__filename', distinct=True)
 
 
@@ -33,4 +63,4 @@ class ModuleFilter(ModuleFilterBase):
         model = Module
         fields = ('uid', 'name', 'stream', 'version', 'context', 'active', 'koji_tag',
                   'runtime_dep_name', 'runtime_dep_stream', 'build_dep_name', 'build_dep_stream',
-                  'component_name', 'component_branch')
+                  'component_name', 'component_branch', 'component')

--- a/pdc/apps/module/tests.py
+++ b/pdc/apps/module/tests.py
@@ -161,6 +161,20 @@ class ModuleAPITestCase(TestCaseWithChangeSetMixin, APITestCase):
                                         format='json')
         self.assertEqual(response_nine.data['count'], 0)
 
+        # Filtering by both RPM name and branch ("component" filter)
+        response = self.client.get(url, data={'component': 'foobar'}, format='json')
+        self.assertEqual(response.data['count'], 2)
+        response = self.client.get(
+            url, data={'component': 'foobar/master'}, format='json')
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['results'][0]['uid'], uid_one)
+        response = self.client.get(
+            url, data={'component': 'foobar/f27'}, format='json')
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['results'][0]['uid'], uid_two)
+        response = self.client.get(url, data={'component': 'python'}, format='json')
+        self.assertEqual(response.data['count'], 0)
+
     def test_create_and_get_module_with_exist_rpms(self):
         url = reverse('modules-list')
         self.data['rpms'] = [{


### PR DESCRIPTION
Filtering by

    rest_api/v1/modules/?component=wayland/master&component=glibc/f28

shall show all components containing either:

- an RPM with **name "wayland" and srpm_commit_branch "master"** or
- an RPM with **name "glibc" and srpm_commit_branch "f28"**.

JIRA: PDC-2254

---

Fixes #458